### PR TITLE
Revolution fixes

### DIFF
--- a/discordbot/embedmanager.py
+++ b/discordbot/embedmanager.py
@@ -145,14 +145,16 @@ class EmbedManager(object):
             if rev_info := guild.get_member(rev):
                 revos.append(rev_info.name)
             else:
-                revos.append(rev)
+                revos.append(str(rev))
 
         supps = []
         for sup in event.get('supporters', []):
             if sup_info := guild.get_member(sup):
                 supps.append(sup_info.name)
             else:
-                supps.append(sup)
+                supps.append(str(sup))
+
+        chance = max(min(event['chance'], 95), 5)
 
         message = (
             f"**REVOLUTION IS UPON US**\n\n"
@@ -167,7 +169,7 @@ class EmbedManager(object):
             "The KING may spend 10% of their eddies using the _Save Thyself_ "
             "button to reduce revolution chance by 15%.\n"
             f"**Event ID**: `{event['event_id']}`\n"
-            f"**Success rate**: `{max(min(event['chance'], 100), 0)}%`\n"
+            f"**Success rate**: `{chance}%`\n"
             f"**Revolutionaries**: `{', '.join(revos) if revos else None}`\n"
             f"**Supporters**: `{', '.join(supps) if supps else None}`\n"
             f"**Locked in KING eddies**: `{event.get('locked_in_eddies')}`\n"

--- a/discordbot/slashcommandeventclasses/autogenerate.py
+++ b/discordbot/slashcommandeventclasses/autogenerate.py
@@ -78,7 +78,7 @@ class BSEddiesAutoGenerate(BSEddies):
                     for member in vc_channel.members:
                         bet["options"].append(member.display_name)
 
-                    if bet["type"] == _type and len(bet["options"]) < 5 and bet.get("fill"):
+                    if bet["type"] == "valorant" and len(bet["options"]) < 5 and bet.get("fill"):
                         bet["options"].append("a rando")
 
             except Exception as e:

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -275,8 +275,8 @@ class BSEddiesRevolutionTask(commands.Cog):
 
         # do roles
 
-        supporter_role = await guild.get_role(guild_db["supporter_role"])  # type: discord.Role
-        revo_role = await guild.get_role(guild_db["revolutionary_role"])
+        supporter_role = guild.get_role(guild_db["supporter_role"])  # type: discord.Role
+        revo_role = guild.get_role(guild_db["revolutionary_role"])
 
         # clear anyone that has the role already
         for member in supporter_role.members:

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -90,10 +90,14 @@ class BSEddiesRevolutionTask(commands.Cog):
                     datetime.datetime.now() + datetime.timedelta(hours=3, minutes=30),
                     king_user["uid"],
                     user_points,
-                    BSEDDIES_REVOLUTION_CHANNEL
+                    guild.id
                 )
             else:
-                event = self.revolutions.get_open_events(guild.id)[0]
+                try:
+                    event = self.revolutions.get_open_events(guild.id)[0]
+                except IndexError:
+                    # this guild doesn't have an open event so let's skip for now
+                    continue
 
             self.rev_started = True
 

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -108,10 +108,10 @@ class BSEddiesRevolutionTask(commands.Cog):
                 continue
 
             elif now.hour == 18 and now.minute == 30 and not event.get("one_hour"):
-                await self.send_excited_gif(guild.id, event, "One hour", "one_hour")
+                await self.send_excited_gif(event, "One hour", "one_hour")
 
             elif now.hour == 19 and now.minute == 15 and not event.get("quarter_house"):
-                await self.send_excited_gif(guild.id, event, "15 MINUTES", "quarter_hour")
+                await self.send_excited_gif(event, "15 MINUTES", "quarter_hour")
 
     async def send_excited_gif(self, event: RevolutionEventType, hours_string: str, key: str):
         """

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -6,7 +6,7 @@ import discord
 from discord.ext import tasks, commands
 
 from apis.giphyapi import GiphyAPI
-from discordbot.bot_enums import TransactionTypes
+from discordbot.bot_enums import SupporterType, TransactionTypes
 from discordbot.constants import BSEDDIES_KING_ROLES, BSEDDIES_REVOLUTION_CHANNEL
 from discordbot.embedmanager import EmbedManager
 from discordbot.views import RevolutionView
@@ -293,11 +293,12 @@ class BSEddiesRevolutionTask(commands.Cog):
                 await member.remove_roles(revo_role)
 
         # supporters get Supporter role
-
+        supporter_type = SupporterType.SUPPORTER
         for supporter in supporters:
             supporter_guild = await guild.fetch_member(supporter)
             if supporter_role not in supporter_guild.roles:
                 await supporter_guild.add_roles(supporter_role)
+            self.user_points.update({"uid": supporter}, {"$set": {"supporter_type": supporter_type}})
 
         # revolutonaries get revolutionary role
 

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -24,13 +24,14 @@ class BSEddiesRevolutionTask(commands.Cog):
         self.embed_manager = EmbedManager(logger)
         self.logger = logger
         self.startup_tasks = startup_tasks
+        self.guild_ids = guilds
         self.guilds = Guilds()
         self.giphy_api = GiphyAPI(giphy_token)
         self.rev_started = False
         self.revolution.start()
 
-        for guild in self.bot.guilds:
-            if _ := self.revolutions.get_open_events(guild.id):
+        for guild_id in self.guild_ids:
+            if _ := self.revolutions.get_open_events(guild_id):
                 self.rev_started = True
 
     def cog_unload(self):

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -194,6 +194,8 @@ class BSEddiesRevolutionTask(commands.Cog):
             return
 
         val = (random.random() * 100)
+        # cap and min chance so that each side _could_ always win
+        chance = max(min(chance, 95), 5)
         success = val <= chance
 
         self.logger.debug(f"Number was: {val} and chance was: {chance}")

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -72,7 +72,7 @@ class BSEddiesRevolutionTask(commands.Cog):
 
             if not self.rev_started:
                 # only trigger if King was King for more than twenty four hours
-                king_since = guild_db["king_since"]
+                king_since = guild_db.get("king_since", datetime.datetime.now() - datetime.timedelta(days=1))
                 if (now - king_since).total_seconds() < 86400:
                     # user hasn't been king for more than twenty four hours
                     channel = await guild.fetch_channel(guild_db["channel"])

--- a/mongo/bsepoints/guilds.py
+++ b/mongo/bsepoints/guilds.py
@@ -67,7 +67,7 @@ class Guilds(BestSummerEverPointsDB):
         Returns:
             int: the channel ID
         """
-        ret = self.query({"guild_id": guild_id}, {"channel": True})
+        ret = self.query({"guild_id": guild_id}, projection={"channel": True})
         if not ret or "channel" not in ret[0]:
             return None
         ret = ret[0]

--- a/mongo/bsepoints/points.py
+++ b/mongo/bsepoints/points.py
@@ -32,7 +32,7 @@ class UserPoints(BestSummerEverPointsDB):
         if ret["points"] > ret.get("high_score", 0):
             self.update({"_id": ret["_id"]}, {"$set": {"high_score": ret["points"]}})
 
-    def find_user(self, user_id: int, guild_id: int, projection=None) -> Union[User, None]:
+    def find_user(self, user_id: int, guild_id: int, projection: Optional[dict] = None) -> Union[User, None]:
         """
         Looks up a user in the collection.
 


### PR DESCRIPTION
#294 - This fixes a number of issues that occured during the last revolution event. These are issues that weren't found during the last running of the event (due to it not happening because of another bug...). The bugs were likely introduced during the changes made with supporters/revolutionaries.

#295 - Caps the revolution chance at 95% and has a minimum of 5%.

#297 - Fixes the issue with the taxrate command failing this morning.