### PR TITLE
Add additional linting check

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          pip install -r requirements.txt
+          pip install -r test-requirements.txt
       - name: Lint with ruff
         run: |
           ruff check .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,4 +1,4 @@
-name: flake8 Lint
+name: Linting
 
 on: [push, pull_request]
 
@@ -13,5 +13,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: flake8 Lint
-        uses: py-actions/flake8@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -r requirements.txt
+      - name: Lint with ruff
+        run: |
+          ruff check .
+      - name: Lint with flake8
+        run: |
+          flake8 .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/discordbot/clienteventclasses/onmessage.py
+++ b/discordbot/clienteventclasses/onmessage.py
@@ -82,9 +82,9 @@ class OnMessage(BaseEvent):
             "I am happy that you're happy!",
             "https://media.giphy.com/media/tXTqLBYNf0N7W/giphy.gif",
             "https://media.giphy.com/media/l41lY4I8lZXH0vIe4/giphy.gif",
-            "https://media.giphy.com/media/1qfb3aFqldWklPQwS3/giphy.gif",
-            "https://media.giphy.com/media/e5nATuISYAZ4Q/giphy.gif",
-            "https://media.giphy.com/media/xT0Cyhi8GCSU91PvtC/giphy.gif",
+            "https://media.giphy.com/media/1qfb3aFqldWklPQwS3/giphy.gif"
+            "https://media.giphy.com/media/e5nATuISYAZ4Q/giphy.gif"
+            "https://media.giphy.com/media/xT0Cyhi8GCSU91PvtC/giphy.gif"
         ]
 
         send_message = False

--- a/discordbot/clienteventclasses/onmessage.py
+++ b/discordbot/clienteventclasses/onmessage.py
@@ -82,8 +82,8 @@ class OnMessage(BaseEvent):
             "I am happy that you're happy!",
             "https://media.giphy.com/media/tXTqLBYNf0N7W/giphy.gif",
             "https://media.giphy.com/media/l41lY4I8lZXH0vIe4/giphy.gif",
-            "https://media.giphy.com/media/1qfb3aFqldWklPQwS3/giphy.gif"
-            "https://media.giphy.com/media/e5nATuISYAZ4Q/giphy.gif"
+            "https://media.giphy.com/media/1qfb3aFqldWklPQwS3/giphy.gif",
+            "https://media.giphy.com/media/e5nATuISYAZ4Q/giphy.gif",
             "https://media.giphy.com/media/xT0Cyhi8GCSU91PvtC/giphy.gif"
         ]
 

--- a/discordbot/embedmanager.py
+++ b/discordbot/embedmanager.py
@@ -32,7 +32,7 @@ class EmbedManager(object):
         )
 
         for option in bet["option_dict"]:
-            betters = [bet['betters'][b] for b in bet['betters'] if bet['betters'][b]["emoji"] == option]
+            betters = [bet["betters"][b] for b in bet["betters"] if bet["betters"][b]["emoji"] == option]
             if betters:
                 val = ""
                 for better in sorted(betters, key=lambda b: b["points"], reverse=True):
@@ -141,20 +141,20 @@ class EmbedManager(object):
         :return:
         """
         revos = []
-        for rev in event.get('revolutionaries', []):
+        for rev in event.get("revolutionaries", []):
             if rev_info := guild.get_member(rev):
                 revos.append(rev_info.name)
             else:
                 revos.append(str(rev))
 
         supps = []
-        for sup in event.get('supporters', []):
+        for sup in event.get("supporters", []):
             if sup_info := guild.get_member(sup):
                 supps.append(sup_info.name)
             else:
                 supps.append(str(sup))
 
-        chance = max(min(event['chance'], 95), 5)
+        chance = max(min(event["chance"], 95), 5)
 
         message = (
             f"**REVOLUTION IS UPON US**\n\n"

--- a/discordbot/slashcommandeventclasses/active.py
+++ b/discordbot/slashcommandeventclasses/active.py
@@ -37,7 +37,7 @@ class BSEddiesActive(BSEddies):
         message = "Here are all the active bets:\n"
 
         for bet in bets:
-            if 'channel_id' not in bet or 'message_id' not in bet:
+            if "channel_id" not in bet or "message_id" not in bet:
                 continue
 
             if bet.get("private"):

--- a/discordbot/slashcommandeventclasses/pending.py
+++ b/discordbot/slashcommandeventclasses/pending.py
@@ -34,7 +34,7 @@ class BSEddiesPending(BSEddies):
         message = "Here are all your pending bets:\n"
 
         for bet in bets:
-            if 'channel_id' not in bet or 'message_id' not in bet:
+            if "channel_id" not in bet or "message_id" not in bet:
                 continue
 
             link = f"https://discordapp.com/channels/{ctx.guild.id}/{bet['channel_id']}/{bet['message_id']}"

--- a/discordbot/slashcommandeventclasses/stats.py
+++ b/discordbot/slashcommandeventclasses/stats.py
@@ -110,11 +110,11 @@ class BSEddiesStats(BSEddies):
         _perc = (diverse_portfolio.users[user_id]["channels"][_chan] / most_messages.value) * 100
         _lf_perc = (diverse_portfolio.users[user_id]["channels"][_least_fav_chan] / most_messages.value) * 100
 
-        _vc_time = int(big_gamer.users.get(user_id, {'count': 0})['count'])
+        _vc_time = int(big_gamer.users.get(user_id, {"count": 0})["count"])
         _king_time = int(time_king.kings.get(user_id, 0))
-        _streaming_time = int(big_streamer.users.get(user_id, {'count': 0})['count'])
-        _dv_num = diverse_portfolio.users.get(user_id, {'channels': {_chan: 0}})['channels'][_chan]
-        _lv_num = diverse_portfolio.users.get(user_id, {'channels': {_least_fav_chan: 0}})['channels'][_least_fav_chan]
+        _streaming_time = int(big_streamer.users.get(user_id, {"count": 0})["count"])
+        _dv_num = diverse_portfolio.users.get(user_id, {"channels": {_chan: 0}})["channels"][_chan]
+        _lv_num = diverse_portfolio.users.get(user_id, {"channels": {_least_fav_chan: 0}})["channels"][_least_fav_chan]
 
         try:
             lft = await self.client.fetch_channel(_least_fav_chan)

--- a/discordbot/slashcommandeventclasses/transactions.py
+++ b/discordbot/slashcommandeventclasses/transactions.py
@@ -83,15 +83,15 @@ class BSEddiesTransactionHistory(BSEddies):
         for item in transaction_history:
             worksheet.write_row(
                 row, 0,
-                [row, TransactionTypes(item['type']).name, item['timestamp'].strftime('%d %b %y %H:%M:%S'),
+                [row, TransactionTypes(item["type"]).name, item["timestamp"].strftime("%d %b %y %H:%M:%S"),
                  item["amount"], item["points"], item.get("bet_id", "N/A"), item.get("loan_id", "N/A"),
                  item.get("user_id", "N/A"), item.get("comment", "No comment")]
             )
             row += 1
 
         center_format = workbook.add_format()
-        center_format.set_align('center')
-        center_format.set_align('vcenter')
+        center_format.set_align("center")
+        center_format.set_align("vcenter")
 
         worksheet.set_column("A:A", cell_format=center_format)
         worksheet.set_column("B:B", width=18)

--- a/discordbot/tasks/eddiekingtask.py
+++ b/discordbot/tasks/eddiekingtask.py
@@ -130,7 +130,7 @@ class BSEddiesKingTask(commands.Cog):
                     "comment": f"Taking King from {prev_king_id}"
                 }
 
-                self.user_points.append_to_activity_history(top_user['uid'], guild.id, activity)
+                self.user_points.append_to_activity_history(top_user["uid"], guild.id, activity)
                 await new.add_roles(role, reason="User is now KING!")
 
                 self.user_points.set_king_flag(top_user["uid"], guild.id, True)

--- a/discordbot/tasks/revolutiontask.py
+++ b/discordbot/tasks/revolutiontask.py
@@ -223,7 +223,7 @@ class BSEddiesRevolutionTask(commands.Cog):
 
         else:
             king_dict = self.user_points.find_user(king_id, guild_id, projection={"points": True})
-            points_to_lose = math.floor(event.get('locked_in_eddies', king_dict["points"]) / 2)
+            points_to_lose = math.floor(event.get("locked_in_eddies", king_dict["points"]) / 2)
 
             total_points_to_distribute = points_to_lose
             for supporter in supporters:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 # requirements for needed for actions / testing / etc
-ruff==0.0.247
+ruff==0.0.252
 flake8==6.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+# requirements for needed for actions / testing / etc
+ruff==0.0.247
+flake8==6.0.0


### PR DESCRIPTION
Change the linting workflow to not use the `flake8` action anymore; but just run `flake8` ourselves. Additionally, add in `ruff` as a linting action. `ruff` is a relatively new linter that I'd like to move to going forwards. However, it doesn't have all the features we require yet so using it in tandem with flake8.

Additionally, fix all the current linting issues so future commits don't fail with the new job.