### PR TITLE
#341 - Use a single MongoClient throughout rest of the code

### DIFF
--- a/discordbot/tasks/guildchecker.py
+++ b/discordbot/tasks/guildchecker.py
@@ -299,7 +299,6 @@ class GuildChecker(commands.Cog):
                     bodies.append(body)
 
                     for _body in bodies:
-                        print(len(_body))
                         await channel.send(content=_body, silent=True, suppress=True)
 
                     self.guilds.set_latest_release(guild.id, release_name)

--- a/mongo/baseclass.py
+++ b/mongo/baseclass.py
@@ -26,7 +26,6 @@ class BaseClass(object):
         :param password: password to login to instance with
         """
         self.cli = interface.get_client(ip, username, password)
-        print(f"Using client {self.cli}: {id(self.cli)}")
         self._vault = None
 
     @property

--- a/mongo/interface.py
+++ b/mongo/interface.py
@@ -25,7 +25,7 @@ CACHED_CLIENT = None  # type: MongoClient
 
 class CachedMongoClient(object):
     """
-    Use a singleton class to handle the single MongoClient object that we need to create 
+    Use a singleton class to handle the single MongoClient object that we need to create
 
     Returns:
         _type_: CachedMongoClient
@@ -45,7 +45,7 @@ class CachedMongoClient(object):
                 serverSelectionTimeoutMS=1000,
             )
             print(f"Creating MongoClient instance: {id(self.client)}")
-    
+
     @property
     def client(self):
         return self._client

--- a/mongo/interface.py
+++ b/mongo/interface.py
@@ -23,13 +23,42 @@ else:
 CACHED_CLIENT = None  # type: MongoClient
 
 
+class CachedMongoClient(object):
+    """
+    Use a singleton class to handle the single MongoClient object that we need to create 
+
+    Returns:
+        _type_: CachedMongoClient
+    """
+    _instance = None
+    _client = None
+
+    def __new__(cls, *args):
+        if cls._instance is None:
+            cls._instance = super(CachedMongoClient, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self, connection: str):
+        if not self._client:
+            self._client = MongoClient(
+                connection,
+                serverSelectionTimeoutMS=1000,
+            )
+            print(f"Creating MongoClient instance: {id(self.client)}")
+    
+    @property
+    def client(self):
+        return self._client
+
+
 def get_client(
     ip: str = "127.0.0.1",
     user_name: Union[str, None] = None,
-    password: Union[str, None] = None
+    password: Union[str, None] = None,
+    port: str = "27017"
 ) -> Union[MongoClient, bool]:
     """
-    Returns a MongoDB Client connection for interacting with MongoDB Database Objects.
+    Returns the MongoDB Client connection for interacting with MongoDB Database Objects.
 
     :param ip: STR - IP address of mongo instance to get client for
     :param user_name: STR - user name to login to instance with
@@ -37,20 +66,17 @@ def get_client(
 
     :returns MongoClient object:
     """
-    global CACHED_CLIENT
-    if CACHED_CLIENT is not None:
-        return CACHED_CLIENT
+
     if user_name is None and password is None:
-        connection = "mongodb://{}:27017".format(ip)
+        connection = f"mongodb://{ip}:{port}"
     elif user_name and password:
         u = quote_plus(user_name)
         p = quote_plus(password)
-        connection = "mongodb://%s:%s@{}:27017".format(ip) % (u, p)
+        connection = f"mongodb://{u}:{p}@{ip}:{port}"
     else:
         return False
-    client = MongoClient(connection, serverSelectionTimeoutMS=1000)
-    CACHED_CLIENT = client
-    print(f"Setting cached mongo client to {client}: : {id(client)}")
+    client_cls = CachedMongoClient(connection)
+    client = client_cls.client
     return client
 
 


### PR DESCRIPTION
We had to do an hotfix earlier in the week to make sure we were using a single MongoClient throughout the code. Previously, we were creating one for each connection which is bad practice. MongoClient already using pooling to handle multiple connections so we only need one instance created for our entire program. Our fix was a bit primitive last time; this is a far more substantial fix using the singleton design pattern.