### PR TITLE
#337 - Make sure stats cache only gets needed transactions and activities

### DIFF
--- a/discordbot/stats/statsdatacache.py
+++ b/discordbot/stats/statsdatacache.py
@@ -80,7 +80,7 @@ class StatsDataCache:
         if self.__message_cache and (now - self.__message_cache_time).total_seconds() < 3600:
             return self.__message_cache
 
-        self.__message_cache = self.user_interactions._paginated_query(
+        self.__message_cache = self.user_interactions.paginated_query(
             {
                 "guild_id": guild_id,
                 "timestamp": {"$gt": start, "$lt": end},
@@ -115,7 +115,7 @@ class StatsDataCache:
         if self.__edit_cache and (now - self.__edit_cache_time).total_seconds() < 3600:
             return self.__edit_cache
 
-        self.__edit_cache = self.user_interactions._paginated_query(
+        self.__edit_cache = self.user_interactions.paginated_query(
             {
                 "guild_id": guild_id,
                 "edited": {"$gt": start, "$lt": end},
@@ -156,7 +156,7 @@ class StatsDataCache:
         if self.__vc_cache and (now - self.__vc_cache_time).total_seconds() < 3600:
             return self.__vc_cache
 
-        self.__vc_cache = self.user_interactions._paginated_query(
+        self.__vc_cache = self.user_interactions.paginated_query(
             {
                 "guild_id": guild_id,
                 "timestamp": {"$gt": start, "$lt": end},
@@ -242,9 +242,7 @@ class StatsDataCache:
         if self.__transaction_cache and (now - self.__transaction_cache_time).total_seconds() < 3600:
             return self.__transaction_cache
 
-        # TODO: #337 make a function here that only gets transactions between datetime
-        _transactions = self.trans.get_all_guild_transactions(guild_id)
-        _transactions = [t for t in _transactions if start < t["timestamp"] < end]
+        _transactions = self.trans.get_guild_transactions_by_timestamp(guild_id, start, end)
         if self.__user_id_cache:
             _transactions = [t for t in _transactions if t["uid"] == self.__user_id_cache]
         self.__transaction_cache = _transactions
@@ -271,9 +269,7 @@ class StatsDataCache:
         if self.__activity_cache and (now - self.__activity_cache_time).total_seconds() < 3600:
             return self.__activity_cache
 
-        # TODO: #337 make a function here that only gets activities between datetime
-        _activities = self.activities.get_all_guild_activities(guild_id)
-        _activities = [a for a in _activities if start < a["timestamp"] < end]
+        _activities = self.activities.get_guild_activities_by_timestamp(guild_id, start, end)
         if self.__user_id_cache:
             _activities = [a for a in _activities if a["uid"] == self.__user_id_cache]
         self.__activity_cache = _activities

--- a/mongo/baseclass.py
+++ b/mongo/baseclass.py
@@ -135,10 +135,17 @@ class BaseClass(object):
         len_ret = limit
         while len_ret == limit:
             # keep looping
-            _messages = self.query(query_dict, limit=limit, skip=skip)
+            ret = interface.query(
+                self.vault,
+                query_dict,
+                limit=limit,
+                projection=None,
+                as_gen=False,
+                skip=skip
+            )
             skip += limit
-            len_ret = len(_messages)
-            docs.extend(_messages)
+            len_ret = len(ret)
+            docs.extend(ret)
         return docs
 
     def get_collection_names(self) -> Union[None, list]:

--- a/mongo/bsepoints/activities.py
+++ b/mongo/bsepoints/activities.py
@@ -36,5 +36,34 @@ class UserActivities(BestSummerEverPointsDB):
         doc.update(kwargs)
         self.insert(doc)
 
+    def get_guild_activities_by_timestamp(
+        self,
+        guild_id: int,
+        start: datetime.datetime,
+        end: datetime.datetime
+    ) -> list[Activity]:
+        """Get guild activities between two timestamps
+
+        Args:
+            guild_id (int): the guild ID
+            start (datetime.datetime): start time
+            end (datetime.datetime): end time
+
+        Returns:
+            list[Activity]: activities between those times
+        """
+        return self.query(
+            {"guild_id": guild_id, "timestamp": {"$gt": start, "$lt": end}},
+            limit=10000
+        )
+
     def get_all_guild_activities(self, guild_id: int) -> list[Activity]:
+        """Get all activities for the given guild ID
+
+        Args:
+            guild_id (int): the guild ID
+
+        Returns:
+            list[Activity]: the activities
+        """
         return self.query({"guild_id": guild_id}, limit=10000)

--- a/mongo/bsepoints/interactions.py
+++ b/mongo/bsepoints/interactions.py
@@ -17,26 +17,9 @@ class UserInteractions(BestSummerEverPointsDB):
         super().__init__()
         self._vault = interface.get_collection(self.database, "userinteractions")
 
-    def _paginated_query(self, query_dict: dict) -> list[Message]:
-        """Performs a paginated query with the specified query dict
-
-        Args:
-            query_dict (dict): a dict of query operators
-
-        Returns:
-            list[Message]: a list of messages for the given query
-        """
-        _lim = 10000
-        messages = []
-        len_messages_ret = _lim
-        skip = 0
-        while len_messages_ret == _lim:
-            # keep looping
-            _messages = self.query(query_dict, limit=_lim, skip=skip)
-            skip += _lim
-            len_messages_ret = len(_messages)
-            messages.extend(_messages)
-        return messages
+    def paginated_query(self, query_dict: dict, limit=1000, skip=0) -> list[Message]:
+        """Overriding to define return type"""
+        return super().paginated_query(query_dict, limit, skip)
 
     def get_all_messages_for_server(self, guild_id: int) -> list[Message]:
         """Gets all messages for a given server

--- a/mongo/bsepoints/transactions.py
+++ b/mongo/bsepoints/transactions.py
@@ -38,5 +38,34 @@ class UserTransactions(BestSummerEverPointsDB):
         doc.update(kwargs)
         self.insert(doc)
 
+    def get_guild_transactions_by_timestamp(
+        self,
+        guild_id: int,
+        start: datetime.datetime,
+        end: datetime.datetime
+    ) -> list[Transaction]:
+        """Get guild transactions between two timestamps
+
+        Args:
+            guild_id (int): the guild ID
+            start (datetime.datetime): start time
+            end (datetime.datetime): end time
+
+        Returns:
+            list[Transaction]: transactions between those times
+        """
+        return self.query(
+            {"guild_id": guild_id, "timestamp": {"$gt": start, "$lt": end}},
+            limit=10000
+        )
+
     def get_all_guild_transactions(self, guild_id: int) -> list[Transaction]:
+        """Get all transactions for a given guild ID
+
+        Args:
+            guild_id (int): the guild ID
+
+        Returns:
+            list[Transaction]: list of transactions
+        """
         return self.query({"guild_id": guild_id}, limit=10000)


### PR DESCRIPTION
As per #337, we changed database schema slightly in #336 so that transactions and activities are tracked in separate collections rather than as embedded documents on each user object. We primitively made the changes to the stats cache classes to pull all transactions and activities. This is a followup update so that we only get activities/transactions for the given timeframe. 

Also moved the `paginated_query` function to `BaseClass` and then adapted the `query` function to use `paginated_query` when appropriate.