### PR TITLE
#359 - Fix error with bot DM messages

### DIFF
--- a/discordbot/clienteventclasses/onmemberjoin.py
+++ b/discordbot/clienteventclasses/onmemberjoin.py
@@ -32,5 +32,6 @@ class OnMemberJoin(BaseEvent):
             self.logger.info(f"Activating BSEddies account for existing user - {user_id} - {member.display_name}")
             return
 
-        self.user_points.create_user(user_id, member.guild.id)
+        name = member.nick or member.name
+        self.user_points.create_user(user_id, member.guild.id, name)
         self.logger.info(f"Creating BSEddies account for new user - {user_id} - {member.display_name}")

--- a/discordbot/commandmanager.py
+++ b/discordbot/commandmanager.py
@@ -359,6 +359,10 @@ class CommandManager(object):
                 self.logger.debug(f"{message} - {message.content}")
                 await self.direct_message.dm_received(message)
                 return
+            elif type(message.channel) == discord.channel.DMChannel and \
+                    message.author.id == self.client.user.id:
+                # message in DM channel from ourselves
+                return
 
             await self.on_message.message_received(message)
 

--- a/mongo/bsepoints/points.py
+++ b/mongo/bsepoints/points.py
@@ -157,18 +157,20 @@ class UserPoints(BestSummerEverPointsDB):
         """
         return self.increment_daily_minimum(user_id, guild_id, amount * -1)
 
-    def create_user(self, user_id: int, guild_id: int, dailies: bool = False) -> None:
+    def create_user(self, user_id: int, guild_id: int, name: str, dailies: bool = False) -> None:
         """
         Create basic user points document.
 
         :param dailies:
         :param user_id: int - The ID of the user to look for
+        :param name: str - username
         :param guild_id: int - The guild ID that the user belongs in
         :return: None
         """
         user_doc = {
             "uid": user_id,
             "guild_id": guild_id,
+            "name": name,
             "points": 10,
             "pending_points": 0,
             "inactive": False,

--- a/mongo/datatypes.py
+++ b/mongo/datatypes.py
@@ -50,6 +50,8 @@ class User(TypedDict):
     """The discord user ID"""
     guild_id: int
     """The discord server ID the user belongs to"""
+    name: str
+    """The nickname for the guild or the user name"""
     points: int
     """The amount of eddies the user has in the server"""
     pending_points: int


### PR DESCRIPTION
Stop bot processing it's own direct messages to other users and failing - fixes #359 
Start storing user names in the DB and add updating them to guild checker task