### PR TITLE
#322 - Application commands and direct messages

### DIFF
--- a/discordbot/slashcommandeventclasses/bseddies.py
+++ b/discordbot/slashcommandeventclasses/bseddies.py
@@ -14,6 +14,7 @@ class BSEddies(BaseEvent):
 
     def __init__(self, client, guilds, logger):
         super().__init__(client, guilds, logger)
+        self.dmable = False
 
     async def _handle_validation(self, ctx: Union[discord.ApplicationContext, discord.Interaction], **kwargs) -> bool:
         """
@@ -22,6 +23,11 @@ class BSEddies(BaseEvent):
         :param kwargs: the additional kwargs to use in validation
         :return: True or False
         """
+        if not ctx.guild and not self.dmable:
+            msg = "This command doesn't work in DMs (yet)."
+            await ctx.respond(content=msg, ephemeral=True)
+            return False
+
         if kwargs.get("admin") and ctx.author.id != CREATOR:
             msg = "You do not have the permissions to use this command."
             await ctx.respond(content=msg, ephemeral=True)

--- a/discordbot/slashcommandeventclasses/view.py
+++ b/discordbot/slashcommandeventclasses/view.py
@@ -3,6 +3,7 @@ import discord
 
 from discordbot.bot_enums import ActivityTypes
 from discordbot.slashcommandeventclasses.bseddies import BSEddies
+from mongo.datatypes import User
 
 
 class BSEddiesView(BSEddies):
@@ -12,6 +13,29 @@ class BSEddiesView(BSEddies):
 
     def __init__(self, client, guilds, logger):
         super().__init__(client, guilds, logger)
+        self.dmable = True
+
+    def _construct_guild_message(self, user: User) -> str:
+        """
+        Constructs the `View` message for a given user and guild
+
+        Args:
+            user (User): the DB Uer object
+
+        Returns:
+            str: the constructed message
+        """
+        guild_db = self.guilds.get_guild(user["guild_id"])
+        if not guild_db:
+            return "Guild didn't exist in guilds collection - probbaly just a debug error"
+        pending = self.user_bets.get_user_pending_points(user["uid"], user["guild_id"])
+        msg = (
+            f"**{guild_db['name']}**\n"
+            f"You have **{user['points']}** :money_with_wings:`BSEDDIES`:money_with_wings:!"
+            f"\nAdditionally, you have `{pending}` points on 'pending bets'.\n\n"
+            f"The _absolute highest_ amount of eddies you've ever had was `{user.get('high_score', 0)}`!."
+        )
+        return msg
 
     async def view(self, ctx: discord.ApplicationContext) -> None:
         """
@@ -26,13 +50,37 @@ class BSEddiesView(BSEddies):
         if not await self._handle_validation(ctx):
             return
 
+        _user = None
+        if not ctx.guild:
+            # no guild - workout if user is in more than one guild or not
+            users = self.user_points.find_user_guildless(ctx.author.id)
+            if len(users) > 1:
+                return await self.view_guildless(ctx, users)
+            elif len(users) == 1:
+                _user = users[0]
+            else:
+                # no guilds at all?
+                await ctx.respond("We do not share any guilds together.")
+                return
+
         self._add_event_type_to_activity_history(ctx.author, ctx.guild_id, ActivityTypes.BSEDDIES_VIEW)
 
-        ret = self.user_points.find_user(
-            ctx.author.id, ctx.guild.id, projection={"points": True, "high_score": True})
+        if not _user:
+            _user = self.user_points.find_user(ctx.author.id, ctx.guild.id)
 
-        pending = self.user_bets.get_user_pending_points(ctx.author.id, ctx.guild.id)
-        msg = (f"You have **{ret['points']}** :money_with_wings:`BSEDDIES`:money_with_wings:!"
-               f"\nAdditionally, you have `{pending}` points on 'pending bets'.\n\n"
-               f"The _absolute highest_ amount of eddies you've ever had was `{ret.get('high_score', 0)}`!.")
+        msg = self._construct_guild_message(_user)
         await ctx.respond(content=msg, ephemeral=True)
+
+    async def view_guildless(self, ctx: discord.ApplicationContext, users: list[User]) -> None:
+        """
+        Sends multiple messages for each guild the user is in
+
+        Args:
+            ctx (discord.ApplicationContext): the context to respond to
+            users (list[User]): the list of users
+        """
+        await ctx.respond("Eddies for all your guilds:")
+
+        for _user in users:
+            msg = self._construct_guild_message(_user)
+            await ctx.followup.send(content=msg)

--- a/discordbot/tasks/guildchecker.py
+++ b/discordbot/tasks/guildchecker.py
@@ -79,11 +79,15 @@ class GuildChecker(BaseTask):
                     guild.id,
                     guild.name,
                     guild.owner_id,
-                    guild.created_at
+                    guild.created_at,
                 )
                 # get new instance of db_guild
                 db_guild = self.guilds.get_guild(guild.id)
                 self.guilds.update_tax_history(guild.id, 0.1, 0.0, self.bot.user.id)
+
+            if db_guild.get("name") != guild.name:
+                self.logger.info(f"Updating db name for {guild.name}")
+                self.guilds.update({"_id": db_guild["_id"]}, {"$set": {"name": guild.name}})
 
             self.logger.info("Checking guilds for new members")
             members = await guild.fetch_members().flatten()

--- a/mongo/bsepoints/points.py
+++ b/mongo/bsepoints/points.py
@@ -35,6 +35,19 @@ class UserPoints(BestSummerEverPointsDB):
         if ret["points"] > ret.get("high_score", 0):
             self.update({"_id": ret["_id"]}, {"$set": {"high_score": ret["points"]}})
 
+    def find_user_guildless(self, user_id: int) -> list[User]:
+        """
+        Returns all matching user objects for the given ID
+
+        Args:
+            user_id (int): the user ID to search for
+
+        Returns:
+            list[User]: the user objects for each guild the user belongs to
+        """
+        ret = self.query({"uid": user_id})
+        return ret
+
     def find_user(self, user_id: int, guild_id: int, projection: Optional[dict] = None) -> Union[User, None]:
         """
         Looks up a user in the collection.

--- a/mongo/datatypes.py
+++ b/mongo/datatypes.py
@@ -302,6 +302,7 @@ class GuildDB(TypedDict):
     wordle_channel: int
     category: int
     role: int
+    name: str
     tax_rate: float
     tax_rate_history: list[dict]
     king: int


### PR DESCRIPTION
- Stop _all_ slash commands from working in DMs unless the `self.dmable` attribute is set.
- Refactor `/view` to let it work in DMs; to prove that we can have functional slash commands in direct messages.
- Add extra functionality to guild sync that keeps the name updated
- Updated GuildDB type to add name attribute