### PR TITLE
#333 - Allow bets to have multiple winners

### DIFF
--- a/discordbot/betmanager.py
+++ b/discordbot/betmanager.py
@@ -23,7 +23,7 @@ class BetManager(object):
         self.user_points = UserPoints()
         self.guilds = Guilds()
 
-    def close_a_bet(self, bet_id: str, guild_id: int, emoji: str) -> dict:
+    def close_a_bet(self, bet_id: str, guild_id: int, emoji: list[str]) -> dict:
         """
         Close a bet from a bet ID.
         Here we also calculate who the winners are and allocate their winnings to them.
@@ -40,16 +40,18 @@ class BetManager(object):
 
         ret_dict = {
             "result": emoji,
-            "outcome_name": ret["option_dict"][emoji],
+            "outcome_name": [ret["option_dict"][e] for e in emoji],
             "timestamp": datetime.datetime.now(),
-            "losers": {b: ret["betters"][b]["points"]
-                       for b in ret["betters"] if ret["betters"][b]["emoji"] != emoji},
+            "losers": {
+                b: ret["betters"][b]["points"]
+                for b in ret["betters"] if ret["betters"][b]["emoji"] not in emoji
+            },
             "winners": {}
         }
 
         total_eddies_bet = sum([ret["betters"][b]["points"] for b in ret["betters"]])
         winning_outcome_eddies = sum(
-            [ret["betters"][b]["points"] for b in ret["betters"] if ret["betters"][b]["emoji"] == emoji]
+            [ret["betters"][b]["points"] for b in ret["betters"] if ret["betters"][b]["emoji"] in emoji]
         )
 
         try:
@@ -93,7 +95,7 @@ class BetManager(object):
         total_eddies_taxed = 0
 
         # assign winning points to the users who got the answer right
-        winners = [b for b in ret["betters"] if ret["betters"][b]["emoji"] == emoji]
+        winners = [b for b in ret["betters"] if ret["betters"][b]["emoji"] in emoji]
         for better in winners:
             points_bet = ret["betters"][better]["points"]
             points_won = math.ceil(((m * points_bet) + c) * points_bet)

--- a/discordbot/selects/betoutcomes.py
+++ b/discordbot/selects/betoutcomes.py
@@ -6,7 +6,7 @@ from discordbot.selects.betamount import BetSelectAmount
 
 
 class BetOutcomesSelect(Select):
-    def __init__(self, outcomes: list, enable_type=BetSelectAmount):
+    def __init__(self, outcomes: list, enable_type=BetSelectAmount, close: bool = False):
         """
 
         :param outcomes:
@@ -23,7 +23,7 @@ class BetOutcomesSelect(Select):
             disabled=not outcomes,
             placeholder="Select an outcome",
             min_values=1,
-            max_values=1,
+            max_values=len(options) if close else 1,
             options=options
         )
 
@@ -36,9 +36,9 @@ class BetOutcomesSelect(Select):
         :param interaction:
         :return:
         """
-        selected_outcome = interaction.data["values"][0]
+        selected_outcomes = interaction.data["values"]
         for option in self.options:
-            option.default = option.value == selected_outcome
+            option.default = option.value in selected_outcomes
 
         for child in self.view.children:
             if type(child) == self.enable:

--- a/discordbot/slashcommandeventclasses/place.py
+++ b/discordbot/slashcommandeventclasses/place.py
@@ -3,7 +3,7 @@ from typing import Union
 
 import discord
 
-import discordbot.views as views
+import discordbot.views.bet
 from discordbot.bot_enums import ActivityTypes
 from discordbot.slashcommandeventclasses.bseddies import BSEddies
 from discordbot.slashcommandeventclasses.close import BSEddiesCloseBet
@@ -86,7 +86,7 @@ class BSEddiesPlaceBet(BSEddies):
             await response.edit_message(content=msg, view=None)
             return
 
-        view = views.BetView(bet, self, self.bseddies_close)
+        view = discordbot.views.bet.BetView(bet, self, self.bseddies_close)
 
         if not bet["active"]:
             msg = f"Your reaction on **Bet {bet_id}** failed as the bet is closed for new bets."

--- a/discordbot/views/close.py
+++ b/discordbot/views/close.py
@@ -22,11 +22,11 @@ class CloseABetView(discord.ui.View):
         else:
             options = []
 
-        self.add_item(BetOutcomesSelect(options, discord.ui.Button))
-        self.submit_callback = submit_callback
+        self.add_item(BetOutcomesSelect(options, discord.ui.Button, True))
+        self._submit_callback = submit_callback
 
     @discord.ui.button(label="Submit", style=discord.ButtonStyle.green, row=2, disabled=True)
-    async def submit_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+    async def submit_button_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
 
         data = {}
         for child in self.children:
@@ -37,10 +37,10 @@ class CloseABetView(discord.ui.View):
                     # this means that this was default
                     data["bet_id"] = child.options[0].value
             elif type(child) == BetOutcomesSelect:
-                data["emoji"] = child.values[0]
+                data["emoji"] = child.values
 
         # call the callback that actually places the bet
-        await self.submit_callback(
+        await self._submit_callback(
             interaction,
             data["bet_id"],
             data["emoji"]

--- a/discordbot/views/place.py
+++ b/discordbot/views/place.py
@@ -33,7 +33,7 @@ class PlaceABetView(discord.ui.View):
         await self.message.edit(content="This `place` command timed out - please _place_ another one", view=None)
 
     @discord.ui.button(label="Submit", style=discord.ButtonStyle.green, row=3, disabled=True, emoji="💰")
-    async def submit_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+    async def submit_button_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
 
         data = {}
         for child in self.children:


### PR DESCRIPTION
- modify `close` and related things to allow bets to have multiple winning outcomes. Users can still only select one outcome.
- fix some naming issues
- fix a circular import
- tidy up guildchecker a bit