### PR TITLE
#83 - Automatically restart the bot

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+# this is safe as it doesn't affect running containers
+# data from mongo container isn't stored in a docker volume
+docker system prune -af
+docker stop bsebot && docker rm bsebot && docker run --pull="always" -d --name bsebot --network="host" --restart="always" elliotsloman/bsebot:latest


### PR DESCRIPTION
Add bash file for automatically restarting the bot. This is already running every few days via cron. This allows changes to go in, get approved, and merged into main and then picked up automatically without me having to log in to the server to apply them.