### PR TITLE
#293 - Add /remindme functionality

### DIFF
--- a/discordbot/commandmanager.py
+++ b/discordbot/commandmanager.py
@@ -24,7 +24,7 @@ from discordbot.clienteventclasses import OnMessage, OnMessageEdit, OnReactionAd
 from discordbot.clienteventclasses import OnThreadCreate, OnThreadUpdate, OnVoiceStateChange
 
 from discordbot.embedmanager import EmbedManager
-from discordbot.modals import BSEddiesBetCreateModal, BSEddiesImprovementSuggest
+from discordbot.modals import BSEddiesBetCreateModal, BSEddiesImprovementSuggest, ReminderModal
 
 # slash commands
 from discordbot.slashcommandeventclasses.active import BSEddiesActive
@@ -63,6 +63,7 @@ from discordbot.tasks.guildchecker import GuildChecker
 from discordbot.tasks.messagesync import MessageSync
 from discordbot.tasks.monthlyawards import MonthlyBSEddiesAwards
 from discordbot.tasks.releasechecker import ReleaseChecker
+from discordbot.tasks.reminders import RemindersTask
 from discordbot.tasks.revolutiontask import BSEddiesRevolutionTask
 from discordbot.tasks.threadmutetask import ThreadSpoilerTask
 from discordbot.tasks.wordlereminder import WordleReminder
@@ -200,6 +201,7 @@ class CommandManager(object):
         self.wordle_task = WordleTask(self.client, guilds, self.logger, startup_tasks)
         self.wordle_reminder = WordleReminder(self.client, guilds, self.logger, startup_tasks)
         self.celebrations_task = Celebrations(self.client, guilds, self.logger, startup_tasks)
+        self.reminders_task = RemindersTask(self.client, guilds, self.logger, startup_tasks)
 
         # call the methods that register the events we're listening for
         self._register_client_events()
@@ -677,6 +679,15 @@ class CommandManager(object):
             )
             await ctx.response.send_modal(modal)
 
+        @self.client.command(description="Set a reminder")
+        async def remindme(ctx: discord.ApplicationContext):
+            modal = ReminderModal(
+                self.logger,
+                None,
+                title="Set a reminder"
+            )
+            await ctx.response.send_modal(modal)
+
         @self.client.command(description="See your 2022 replay")
         async def wrapped22(ctx: discord.ApplicationContext):
             """_summary_
@@ -709,10 +720,26 @@ class CommandManager(object):
 
         @self.client.message_command(name="Delete message")
         async def delete_message(ctx: discord.ApplicationCommand, message: discord.Message):
-            """_summary_
+            """Allows BSEddies admins to delete a message
 
             Args:
                 ctx (discord.ApplicationCommand): _description_
                 message (discord.Message): _description_
             """
             await self.message_delete.message_delete(ctx, message)
+
+        @self.client.message_command(name="Remind me")
+        async def remind_me(ctx: discord.ApplicationCommand, message: discord.Message):
+            """
+            Allows triggering of the reminder modal using an existing message.
+
+            Args:
+                ctx (discord.ApplicationCommand): _description_
+                message (discord.Message): _description_
+            """
+            modal = ReminderModal(
+                self.logger,
+                message.id,
+                title="Set a reminder"
+            )
+            await ctx.response.send_modal(modal)

--- a/discordbot/modals.py
+++ b/discordbot/modals.py
@@ -2,13 +2,16 @@
 """
 File for containing the UI modal dialogues that the bot will create
 """
+import datetime
 
 import discord
 
+import discordbot.utilities
 from apis.github import GitHubAPI
 from discordbot.slashcommandeventclasses.close import BSEddiesCloseBet
 from discordbot.slashcommandeventclasses.create import BSEddiesCreateBet
 from discordbot.slashcommandeventclasses.place import BSEddiesPlaceBet
+from mongo.bsepoints.reminders import ServerReminders
 
 
 class BSEddiesBetCreateModal(discord.ui.Modal):
@@ -33,7 +36,9 @@ class BSEddiesBetCreateModal(discord.ui.Modal):
             discord.ui.InputText(
                 label="Timeout: DIGITS + (s|m|h|d|w) (Optional)",
                 required=False,
-                placeholder="Examples: 25m, 2d, 8h, 6h30m, 1w3d2h, etc..."
+                placeholder=(
+                    "Examples: 30m, 8h, 1d12h, 12h30m10s, 1w3d2h, etc..."
+                )
             )
         )
 
@@ -136,3 +141,70 @@ class BSEddiesImprovementSuggest(discord.ui.Modal):
             content=msg,
             ephemeral=True
         )
+
+
+class ReminderModal(discord.ui.Modal):
+    def __init__(self, logger, message_id, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.logger = logger
+        self.server_reminders = ServerReminders()
+        self.message_id = message_id
+
+        self.reminder_reason = discord.ui.InputText(
+            label="Reminder name/reason",
+            placeholder="Remind you about..."
+        )
+
+        self.reminder_timeout = discord.ui.InputText(
+            label="Timeout: DIGITS + (s|m|h|d|w) (Optional)",
+            placeholder=(
+                "Examples: 30m, 8h, 1d12h, 12h30m10s, 1w3d2h, etc..."
+            )
+        )
+
+        self.add_item(self.reminder_reason)
+        self.add_item(self.reminder_timeout)
+
+    async def callback(self, interaction: discord.Interaction):
+        """
+
+        :param interaction:
+        :return:
+        """
+        await interaction.response.defer(ephemeral=True)
+
+        reason = self.reminder_reason.value
+        timeout = self.reminder_timeout.value
+
+        timeout_seconds = discordbot.utilities.convert_time_str(timeout)
+
+        now = datetime.datetime.now()
+        timeout_date = now + datetime.timedelta(seconds=timeout_seconds)
+
+        self.logger.info(f"{reason} - {timeout} - {timeout_seconds}")
+
+        reminder_msg = (
+            f"{interaction.user.mention} you will be reminded about **{reason}** "
+            f"at {str(timeout_date)}"
+        )
+
+        if not self.message_id:
+            reminder_message = await interaction.channel.send(
+                content=reminder_msg
+            )
+        else:
+            await interaction.followup.send(content=reminder_msg, ephemeral=True)
+
+        self.server_reminders.insert_reminder(
+            interaction.guild.id,
+            interaction.user.id,
+            now,
+            timeout_date,
+            reason,
+            interaction.channel.id,
+            self.message_id or reminder_message.id
+        )
+
+        if not self.message_id:
+            await interaction.followup.send(content="Reminder set.", ephemeral=True)

--- a/discordbot/tasks/basetask.py
+++ b/discordbot/tasks/basetask.py
@@ -12,6 +12,7 @@ from mongo.bsepoints.emojis import ServerEmojis
 from mongo.bsepoints.guilds import Guilds
 from mongo.bsepoints.interactions import UserInteractions
 from mongo.bsepoints.points import UserPoints
+from mongo.bsepoints.reminders import ServerReminders
 from mongo.bsepoints.stickers import ServerStickers
 from mongo.bsedataclasses import SpoilerThreads
 from mongo.bsedataclasses import WordleAttempts
@@ -46,9 +47,9 @@ class BaseTask(commands.Cog):
         self.revolutions = RevolutionEvent()
         self.interactions = UserInteractions()
         self.guilds = Guilds()
+        self.server_reminders = ServerReminders()
         self.spoilers = SpoilerThreads()
         self.wordles = WordleAttempts()
-        self.spoilers = SpoilerThreads()
 
     def _check_start_up_tasks(self) -> bool:
         """

--- a/discordbot/tasks/reminders.py
+++ b/discordbot/tasks/reminders.py
@@ -1,0 +1,63 @@
+
+import asyncio
+import datetime
+from logging import Logger
+
+from discord.ext import tasks
+
+from discordbot.bsebot import BSEBot
+from discordbot.tasks.basetask import BaseTask
+
+
+class RemindersTask(BaseTask):
+    def __init__(
+        self,
+        bot: BSEBot,
+        guild_ids: list[int],
+        logger: Logger,
+        startup_tasks: list[BaseTask]
+    ):
+
+        super().__init__(bot, guild_ids, logger, startup_tasks)
+        self.reminders.start()
+
+    def cog_unload(self):
+        """
+        Method for cancelling the loop.
+        :return:
+        """
+        self.reminders.cancel()
+
+    @tasks.loop(minutes=1)
+    async def reminders(self):
+        """
+        Loop that triggers reminders
+        :return:
+        """
+
+        now = datetime.datetime.now()
+        for guild in self.bot.guilds:
+
+            open_reminders = self.server_reminders.get_open_reminders(guild.id)
+            for reminder in open_reminders:
+                if now > reminder["timeout"]:
+                    # time to do reminder
+                    channel = await guild.fetch_channel(reminder["channel_id"])
+                    message = await channel.fetch_message(reminder["message_id"])
+
+                    msg = (
+                        f"Hey, <@{reminder['user_id']}>, don't forget about `{reminder['reason']}`!"
+                    )
+
+                    await message.reply(content=msg)
+                    self.server_reminders.close_reminder(reminder["_id"])
+
+    @reminders.before_loop
+    async def before_reminders(self):
+        """
+        Make sure that websocket is open before we start querying via it.
+        :return:
+        """
+        await self.bot.wait_until_ready()
+        while not self._check_start_up_tasks():
+            await asyncio.sleep(5)

--- a/mongo/bsepoints/reminders.py
+++ b/mongo/bsepoints/reminders.py
@@ -1,0 +1,75 @@
+
+import datetime
+from bson import ObjectId
+from pymongo.results import UpdateResult
+
+from mongo import interface
+from mongo.datatypes import Reminder
+from mongo.db_classes import BestSummerEverPointsDB
+
+
+class ServerReminders(BestSummerEverPointsDB):
+    """
+    Class for interacting with the 'reminders' MongoDB collection in the 'bestsummereverpoints' DB
+    """
+    def __init__(self):
+        """
+        Constructor method for the class. Initialises the collection object
+        """
+        super().__init__()
+        self._vault = interface.get_collection(self.database, "reminders")
+
+    def get_open_reminders(self, guild_id: int) -> list[Reminder]:
+        """
+        Get all the currently open reminders for the given guild
+        :param guild_id:
+        :return:
+        """
+        ret = self.query({"active": True, "guild_id": guild_id})
+        return ret
+
+    def close_reminder(self, object_id: ObjectId) -> UpdateResult:
+        """Closes a reminder
+
+        Args:
+            object_id (ObjectId): objectID of the reminder
+
+        Returns:
+            UpdateResult: update result
+        """
+        return self.update({"_id": object_id}, {"$set": {"active": False}})
+
+    def insert_reminder(
+            self,
+            guild_id: int,
+            user_id: int,
+            created: datetime.datetime,
+            timeout: datetime.datetime,
+            reason: str,
+            channel_id: int,
+            message_id: int
+    ) -> list:
+        """
+        Inserts a reminder into the database.
+
+        Args:
+            guild_id (int): guild ID the reminder exists in
+            user_id (int): the user ID who triggered the reminder
+            created (datetime.datetime): when the reminder was created
+            timeout (datetime.datetime): when we should remind the user
+            reason (str): the reason the user gave for the reminder
+            channel_id (int): the channel ID we sent with reminder details
+            message_id (int): the message ID we sent with reminder details
+        """
+        doc = {
+            "created": created,
+            "user_id": user_id,
+            "guild_id": guild_id,
+            "reason": reason,
+            "timeout": timeout,
+            "channel_id": channel_id,
+            "message_id": message_id,
+            "active": True
+        }
+
+        return self.insert(doc)

--- a/mongo/datatypes.py
+++ b/mongo/datatypes.py
@@ -323,3 +323,15 @@ class GuildDB(TypedDict):
     valorant_rollcall: bool
     valorant_channel: int
     valorant_role: int
+
+
+class Reminder(TypedDict):
+    _id: ObjectId
+    guild_id: int
+    created: datetime.datetime
+    user_id: int
+    timeout: datetime.datetime
+    active: bool
+    reason: str
+    channel_id: int
+    message_id: int


### PR DESCRIPTION
Add functionality for reminders. There are two ways to create a reminder:
- using a slash command `/remindme`
- right-clicking a message and using a context menu command Both methods will trigger a modal to be filled out. This will then enter a reminder into the database.

A new task has been added to check for expired reminders.