### PR TITLE
#128, #121 - Revolution view refactor

### DIFF
--- a/discordbot/views/revolution.py
+++ b/discordbot/views/revolution.py
@@ -6,7 +6,6 @@ import discord
 
 from discordbot.bsebot import BSEBot
 from discordbot.bot_enums import ActivityTypes, TransactionTypes
-from discordbot.constants import BSEDDIES_KING_ROLES
 from discordbot.embedmanager import EmbedManager
 
 from mongo.bsepoints.activities import UserActivities
@@ -33,15 +32,45 @@ class RevolutionView(discord.ui.View):
         for child in self.children:
             child.disabled = disable
 
-    @discord.ui.button(
-        label="OVERTHROW",
-        style=discord.ButtonStyle.green,
-        custom_id="overthrow_button",
-        emoji="🔥"
-    )
-    async def overthrow_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
-        response = interaction.response  # type: discord.InteractionResponse
-        followup = interaction.followup  # type: discord.Webhook
+    async def _revolution_button_logic(
+            self,
+            interaction: discord.Interaction,
+            button: discord.Button
+    ) -> None:
+        """
+        Function for abstracting the revolution button logic.
+        The logic is slightly different for each of the buttons but there's a lot of
+        shared functionality so we can reduce this complexity by putting it all in
+        one place.
+
+        Check that the revolution event is still valid; aka still open and not expired.
+        Check that the right user isn't pressing the wrong buttons;
+        - the king can't press support/overthrow
+        - the king can only press SAVE THYSELF
+
+        Defines some args based on the button pressed for use throughout the logic.
+
+        If we're support/overthrow:
+            - check that we haven't already done the action we're pressing
+            - check that we're not locked in to supporting
+            - if we previously pressed the other button, reverse those effects
+            - apply effects of this button
+        If button is KING button:
+            - calculate eddies to remove from King
+            - remove those eddies
+            - lower the chance
+
+        Update event in DB
+        Update message in discord
+        Add transactions/activities to DB
+        Send ephemeral message to user
+
+        Args:
+            interaction (discord.Interaction): _description_
+            button (discord.Button): _description_
+        """
+        response = interaction.response
+        followup = interaction.followup
 
         self.toggle_stuff(True)
 
@@ -50,6 +79,7 @@ class RevolutionView(discord.ui.View):
 
         event = self.revolutions.get_event(interaction.guild.id, self.event_id)
 
+        # check event is still valid
         if not event["open"]:
             await followup.send(content="Unfortunately, this event has expired", ephemeral=True)
             # leave it disabled
@@ -71,70 +101,146 @@ class RevolutionView(discord.ui.View):
             {"points": True, "king": True}
         )
 
-        if our_user.get("king", False):
-            await followup.send(content="You ARE the King - you can't overthrow yourself.", ephemeral=True)
-            self.toggle_stuff(False)
-            await followup.edit_message(interaction.message.id, view=self)
-            return
-
-        if user_id in event["revolutionaries"]:
+        # check that the King isn't using buttons they shouldn't
+        if our_user.get("king", False) and button.label != "Save THYSELF":
             await followup.send(
-                content="You've already acted on this - you cannot do so again",
+                content="You ARE the King - you can't overthrow/support yourself.",
                 ephemeral=True
             )
             self.toggle_stuff(False)
             await followup.edit_message(interaction.message.id, view=self)
             return
 
-        if user_id in self.locked_in:
-            await followup.send(
-                content="You've pledged your support this week - you _cannot_ change your decision.",
-                ephemeral=True
-            )
+        # check that users aren't using buttons they shouldn't
+        if button.label == "Save THYSELF" and event["king"] != interaction.user.id:
+            await followup.send(content="You're not the King - so you can't use this button.", ephemeral=True)
             self.toggle_stuff(False)
             await followup.edit_message(interaction.message.id, view=self)
             return
 
-        if user_id in event["supporters"]:
-            event["chance"] += 15
-            event["supporters"].remove(user_id)
+        # match statement for the variables that are different for the different factions
+        match button.label:
+            case "OVERTHROW":
+                faction_event_key = "revolutionaries"
+                other_faction_event_key = "supporters"
+                faction_chance = 15
+                act_type = ActivityTypes.REV_OVERTHROW
+                msg = "Congrats - you've pledged to `overthrow`!"
+            case "SUPPORT THE KING":
+                faction_event_key = "supporters"
+                other_faction_event_key = "revolutionaries"
+                faction_chance = -15
+                act_type = ActivityTypes.REV_SUPPORT
+                msg = "Congrats - you've pledged your `support`!"
+            case "Save THYSELF":
+                act_type = ActivityTypes.REV_SAVE
+                msg = "Congrats - you've reduced the overthrow chance."
 
-        event["revolutionaries"].append(user_id)
-        event["chance"] += 15
+        if button.label in ["OVERTHROW", "SUPPORT_THE_KING"]:
+            # logic for overthrow/supporting
+            # different to king button logic
 
-        if user_id not in event["users"]:
-            event["users"].append(user_id)
+            # make sure user isn't doing the same thing twice
+            if user_id in event[faction_event_key]:
+                await followup.send(
+                    content="You've already acted on this - you cannot do so again",
+                    ephemeral=True
+                )
+                self.toggle_stuff(False)
+                await followup.edit_message(interaction.message.id, view=self)
+                return
 
+            # make sure locked in users stay locked in
+            if user_id in self.locked_in:
+                await followup.send(
+                    content="You've pledged your support this week - you _cannot_ change your decision.",
+                    ephemeral=True
+                )
+                self.toggle_stuff(False)
+                await followup.edit_message(interaction.message.id, view=self)
+                return
+
+            # reverse actions of other faction
+            if user_id in event[other_faction_event_key]:
+                event["chance"] -= (faction_chance * -1)
+                event[other_faction_event_key].remove(user_id)
+
+            # apply our actions (increasing/reducing chance)
+            event[faction_event_key].append(user_id)
+            event["chance"] += faction_chance
+
+            if user_id not in event["users"]:
+                event["users"].append(user_id)
+
+        elif button.label == "Save THYSELF":
+            # logic for saving thyself
+            # it is different to supporter/revolutionary logic
+
+            # work out how many eddies to subtract
+            eddies = our_user["points"]
+            amount_to_subtract = math.floor(eddies * 0.1)
+            self.user_points.increment_points(
+                user_id,
+                guild_id,
+                amount_to_subtract * -1,
+                TransactionTypes.REVOLUTION_SAVE
+            )
+
+            event["chance"] -= 15
+            event["times_saved"] += 1
+            msg = (
+                f"{interaction.user.mention} just spent `{amount_to_subtract}` "
+                "to reduce the overthrow chance by **15%**."
+            )
+            await interaction.channel.send(content=msg)
+
+        # update DB with all the changes we've made
         self.revolutions.update(
             {"_id": event["_id"]},
             {"$set": {
                 "chance": event["chance"],
                 "supporters": event["supporters"],
                 "revolutionaries": event["revolutionaries"],
-                "users": event["users"]
+                "users": event["users"],
+                "times_saved": event["times_saved"]
             }}
         )
 
         self.activities.add_activity(
             user_id,
             guild_id,
-            ActivityTypes.REV_OVERTHROW,
+            act_type,
             event_id=event["event_id"]
         )
 
-        king_id = self.guilds.get_king(guild_id)
-
+        # build new message and update it with updated event
+        guild_db = self.guilds.get_guild(guild_id)
+        king_id = guild_db["king"]
         king_user = await self.client.fetch_user(king_id)  # type: discord.User
         guild = await self.client.fetch_guild(guild_id)
-
-        role = guild.get_role(BSEDDIES_KING_ROLES[guild_id])
-
+        role = guild.get_role(guild_db["role"])
         edited_message = self.embeds.get_revolution_message(king_user, role, event, guild)
-
         self.toggle_stuff(False)
 
         await followup.edit_message(interaction.message.id, view=self, content=edited_message)
-        await followup.send(content="Congrats - you've pledged to `overthrow`!", ephemeral=True)
+        await followup.send(content=msg, ephemeral=True)
+
+    @discord.ui.button(
+        label="OVERTHROW",
+        style=discord.ButtonStyle.green,
+        custom_id="overthrow_button",
+        emoji="🔥"
+    )
+    async def overthrow_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """
+        Callback for the Overthrow button.
+        Defers to the button logic method for handling the logic.
+
+        Args:
+            button (discord.ui.Button): the button being pressed
+            interaction (discord.Interaction): the interaction context
+        """
+        await self._revolution_button_logic(interaction, button)
 
     @discord.ui.button(
         label="SUPPORT THE KING",
@@ -143,103 +249,15 @@ class RevolutionView(discord.ui.View):
         emoji="👑"
     )
     async def support_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """
+        Callback for the SUPPORT button button.
+        Defers to the button logic method for handling the logic.
 
-        response = interaction.response  # type: discord.InteractionResponse
-        followup = interaction.followup  # type: discord.Webhook
-
-        self.toggle_stuff(True)
-
-        # disable these whilst we do revolution stuff
-        await response.edit_message(view=self)
-
-        event = self.revolutions.get_event(interaction.guild.id, self.event_id)
-
-        if not event["open"]:
-            await followup.send(content="Unfortunately, this event has expired", ephemeral=True)
-            # leave it disabled
-            return
-
-        now = datetime.datetime.now()
-
-        if event["expired"] < now:
-            await followup.send(content="Unfortunately, this event has expired", ephemeral=True)
-            # leave it disabled
-            return
-
-        user_id = interaction.user.id
-        guild_id = interaction.guild.id
-
-        our_user = self.user_points.find_user(
-            user_id,
-            guild_id,
-            {"points": True, "king": True}
-        )
-
-        if our_user.get("king", False):
-            await followup.send(content="You ARE the King - you can't support yourself.", ephemeral=True)
-            self.toggle_stuff(False)
-            await followup.edit_message(interaction.message.id, view=self)
-            return
-
-        if user_id in event["supporters"]:
-            await followup.send(
-                content="You've already acted on this - you cannot do so again",
-                ephemeral=True
-            )
-            self.toggle_stuff(False)
-            await followup.edit_message(interaction.message.id, view=self)
-            return
-
-        if user_id in self.locked_in:
-            await followup.send(
-                content="You've pledged your support this week - you _cannot_ change your decision.",
-                ephemeral=True
-            )
-            self.toggle_stuff(False)
-            await followup.edit_message(interaction.message.id, view=self)
-            return
-
-        if user_id in event["revolutionaries"]:
-            event["chance"] -= 15
-            event["revolutionaries"].remove(user_id)
-
-        if user_id not in event["users"]:
-            event["users"].append(user_id)
-
-        if user_id not in event["supporters"]:
-            event["supporters"].append(user_id)
-            event["chance"] -= 15
-
-        self.revolutions.update(
-            {"_id": event["_id"]},
-            {"$set": {
-                "chance": event["chance"],
-                "supporters": event["supporters"],
-                "revolutionaries": event["revolutionaries"],
-                "users": event["users"]
-            }}
-        )
-
-        self.activities.add_activity(
-            user_id,
-            guild_id,
-            ActivityTypes.REV_SUPPORT,
-            event_id=event["event_id"]
-        )
-
-        king_id = self.guilds.get_king(guild_id)
-
-        king_user = await self.client.fetch_user(king_id)  # type: discord.User
-        guild = await self.client.fetch_guild(guild_id)
-
-        role = guild.get_role(BSEDDIES_KING_ROLES[guild_id])
-
-        edited_message = self.embeds.get_revolution_message(king_user, role, event, guild)
-
-        self.toggle_stuff(False)
-
-        await followup.edit_message(interaction.message.id, view=self, content=edited_message)
-        await followup.send(content="Congrats - you've pledged your `support`!", ephemeral=True)
+        Args:
+            button (discord.ui.Button): the button being pressed
+            interaction (discord.Interaction): the interaction context
+        """
+        await self._revolution_button_logic(interaction, button)
 
     @discord.ui.button(
         label="Save THYSELF",
@@ -248,77 +266,12 @@ class RevolutionView(discord.ui.View):
         emoji="💵"
     )
     async def save_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """
+        Callback for the Save THYSELF button.
+        Defers to the button logic method for handling the logic.
 
-        response = interaction.response  # type: discord.InteractionResponse
-        followup = interaction.followup  # type: discord.Webhook
-
-        self.toggle_stuff(True)
-
-        # disable these whilst we do revolution stuff
-        await response.edit_message(view=self)
-
-        event = self.revolutions.get_event(interaction.guild.id, self.event_id)
-
-        if not event["open"]:
-            await followup.send(content="Unfortunately, this event has expired", ephemeral=True)
-            # leave it disabled
-            return
-
-        now = datetime.datetime.now()
-
-        if event["expired"] < now:
-            await followup.send(content="Unfortunately, this event has expired", ephemeral=True)
-            # leave it disabled
-            return
-
-        if event["king"] != interaction.user.id:
-            await followup.send(content="You're not the King - so you can't use this button.", ephemeral=True)
-            self.toggle_stuff(False)
-            await followup.edit_message(interaction.message.id, view=self)
-            return
-
-        user_id = interaction.user.id
-        guild_id = interaction.guild.id
-
-        our_user = self.user_points.find_user(
-            user_id,
-            guild_id,
-            {"points": True, "king": True}
-        )
-
-        eddies = our_user["points"]
-        amount_to_subtract = math.floor(eddies * 0.1)
-        self.user_points.increment_points(
-            user_id,
-            guild_id,
-            amount_to_subtract * -1,
-            TransactionTypes.REVOLUTION_SAVE
-        )
-
-        self.activities.add_activity(
-            user_id,
-            guild_id,
-            ActivityTypes.REV_SAVE,
-            event_id=event["event_id"]
-        )
-
-        event["chance"] -= 15
-        event["times_saved"] += 1
-        self.revolutions.update(
-            {"_id": event["_id"]},
-            {"$set": {
-                "chance": event["chance"],
-                "times_saved": event["times_saved"]
-            }}
-        )
-
-        guild = await self.client.fetch_guild(guild_id)
-
-        role = guild.get_role(BSEDDIES_KING_ROLES[guild_id])
-
-        edited_message = self.embeds.get_revolution_message(interaction.user, role, event, guild)
-
-        msg = f"{interaction.user.mention} just spent `{amount_to_subtract}` to reduce the overthrow chance by **15%**."
-        await followup.send(content=msg)
-        self.toggle_stuff(False)
-        await followup.edit_message(interaction.message.id, view=self, content=edited_message)
+        Args:
+            button (discord.ui.Button): the button being pressed
+            interaction (discord.Interaction): the interaction context
+        """
+        await self._revolution_button_logic(interaction, button)

--- a/discordbot/views/revolution.py
+++ b/discordbot/views/revolution.py
@@ -252,7 +252,10 @@ class RevolutionView(discord.ui.View):
         self.toggle_stuff(False)
 
         await followup.edit_message(interaction.message.id, view=self, content=edited_message)
-        await followup.send(content=msg, ephemeral=True)
+
+        if button.label != "Save THYSELF":
+            # only send followup for users
+            await followup.send(content=msg, ephemeral=True)
 
     @discord.ui.button(
         label="OVERTHROW",

--- a/discordbot/views/revolution.py
+++ b/discordbot/views/revolution.py
@@ -50,11 +50,16 @@ class RevolutionView(discord.ui.View):
 
         Defines some args based on the button pressed for use throughout the logic.
 
-        If we're support/overthrow:
+        Non king button:
             - check that we haven't already done the action we're pressing
             - check that we're not locked in to supporting
+
+        If we're support/overthrow:
             - if we previously pressed the other button, reverse those effects
             - apply effects of this button
+        If we're impartial:
+            - remove from revolutionaries/supporters
+            - increase/decrease chance accordingly
         If button is KING button:
             - calculate eddies to remove from King
             - remove those eddies
@@ -95,14 +100,11 @@ class RevolutionView(discord.ui.View):
         user_id = interaction.user.id
         guild_id = interaction.guild.id
 
-        our_user = self.user_points.find_user(
-            user_id,
-            guild_id,
-            {"points": True, "king": True}
-        )
+        guild_db = self.guilds.get_guild(guild_id)
+        king_id = guild_db["king"]
 
         # check that the King isn't using buttons they shouldn't
-        if our_user.get("king", False) and button.label != "Save THYSELF":
+        if (user_id == king_id) and button.label != "Save THYSELF":
             await followup.send(
                 content="You ARE the King - you can't overthrow/support yourself.",
                 ephemeral=True
@@ -112,7 +114,7 @@ class RevolutionView(discord.ui.View):
             return
 
         # check that users aren't using buttons they shouldn't
-        if button.label == "Save THYSELF" and event["king"] != interaction.user.id:
+        if button.label == "Save THYSELF" and (user_id != king_id):
             await followup.send(content="You're not the King - so you can't use this button.", ephemeral=True)
             self.toggle_stuff(False)
             await followup.edit_message(interaction.message.id, view=self)
@@ -135,13 +137,19 @@ class RevolutionView(discord.ui.View):
             case "Save THYSELF":
                 act_type = ActivityTypes.REV_SAVE
                 msg = "Congrats - you've reduced the overthrow chance."
+            case "Impartial":
+                faction_event_key = "neutrals"
+                act_type = ActivityTypes.REV_NEUTRAL
+                msg = "Congrats - you're now impartial."
 
-        if button.label in ["OVERTHROW", "SUPPORT_THE_KING"]:
-            # logic for overthrow/supporting
-            # different to king button logic
+        if button.label != "Save THYSELF":
+            # only do this for the non-KING buttons
+
+            if user_id not in event["users"]:
+                event["users"].append(user_id)
 
             # make sure user isn't doing the same thing twice
-            if user_id in event[faction_event_key]:
+            if user_id in event.get(faction_event_key, []):
                 await followup.send(
                     content="You've already acted on this - you cannot do so again",
                     ephemeral=True
@@ -160,6 +168,10 @@ class RevolutionView(discord.ui.View):
                 await followup.edit_message(interaction.message.id, view=self)
                 return
 
+        if button.label in ["OVERTHROW", "SUPPORT THE KING"]:
+            # logic for overthrow/supporting
+            # different to king button logic
+
             # reverse actions of other faction
             if user_id in event[other_faction_event_key]:
                 event["chance"] -= (faction_chance * -1)
@@ -169,14 +181,32 @@ class RevolutionView(discord.ui.View):
             event[faction_event_key].append(user_id)
             event["chance"] += faction_chance
 
-            if user_id not in event["users"]:
-                event["users"].append(user_id)
+            # remove user from neutrals if they're in it
+            if user_id in event.get("neutrals", []):
+                event["neutrals"].remove(user_id)
+
+        elif button.label == "Impartial":
+            # logic for user pressing the impartial button
+
+            if user_id in event["revolutionaries"]:
+                event["chance"] -= 15
+                event["revolutionaries"].remove(user_id)
+            elif user_id in event["supporters"]:
+                event["chance"] += 15
+                event["supporters"].remove(user_id)
+
+            if user_id not in event["neutrals"]:
+                event["neutrals"].append(user_id)
 
         elif button.label == "Save THYSELF":
             # logic for saving thyself
             # it is different to supporter/revolutionary logic
 
             # work out how many eddies to subtract
+            our_user = self.user_points.find_user(
+                user_id, guild_id,
+                {"points": True, "king": True}
+            )
             eddies = our_user["points"]
             amount_to_subtract = math.floor(eddies * 0.1)
             self.user_points.increment_points(
@@ -201,6 +231,7 @@ class RevolutionView(discord.ui.View):
                 "chance": event["chance"],
                 "supporters": event["supporters"],
                 "revolutionaries": event["revolutionaries"],
+                "neutrals": event["neutrals"],
                 "users": event["users"],
                 "times_saved": event["times_saved"]
             }}
@@ -214,8 +245,6 @@ class RevolutionView(discord.ui.View):
         )
 
         # build new message and update it with updated event
-        guild_db = self.guilds.get_guild(guild_id)
-        king_id = guild_db["king"]
         king_user = await self.client.fetch_user(king_id)  # type: discord.User
         guild = await self.client.fetch_guild(guild_id)
         role = guild.get_role(guild_db["role"])
@@ -250,12 +279,29 @@ class RevolutionView(discord.ui.View):
     )
     async def support_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
         """
-        Callback for the SUPPORT button button.
+        Callback for the SUPPORT button.
         Defers to the button logic method for handling the logic.
 
         Args:
             button (discord.ui.Button): the button being pressed
             interaction (discord.Interaction): the interaction context
+        """
+        await self._revolution_button_logic(interaction, button)
+
+    @discord.ui.button(
+        label="Impartial",
+        style=discord.ButtonStyle.blurple,
+        custom_id="impartial_button",
+        emoji="😐"
+    )
+    async def impartial_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """
+        Callback for the impartial button.
+        Defers to the button logic method for handling the logic.
+
+        Args:
+            button (discord.ui.Button): _description_
+            interaction (discord.Interaction): _description_
         """
         await self._revolution_button_logic(interaction, button)
 

--- a/mongo/bseticketedevents.py
+++ b/mongo/bseticketedevents.py
@@ -90,6 +90,7 @@ class RevolutionEvent(TicketedEvent):
             "chance": 15,
             "revolutionaries": [],
             "supporters": [],
+            "neutrals": [],
             "users": [],
             "ticket_buyers": [],
             "open": True,

--- a/mongo/datatypes.py
+++ b/mongo/datatypes.py
@@ -243,6 +243,8 @@ class RevolutionEventType(TypedDict):
     """list of those supporting the event"""
     revolutionaries: list[int]
     """list of those revolutioning the event"""
+    neutrals: list[int]
+    """list of those impartial to the event"""
     locked: list[int]
     """Users who can't change their decision"""
     users: list[int]


### PR DESCRIPTION
Refactor revolution view to remove a lot of the duplicated code.

All the logic is now abstracted to `_revolution_button_logic` and handles the logic for all buttons. This reduces the amount of duplicated code in the class. I have also added lots more comments in the hope of making it clearer to understand. This paves the way for #121; adding a new "neutral" button for supporters/revolutionaries wanting to reset their stance.

Added a new button (#121), an impartial button. This allow users to reset their choice without choosing the other faction.