### PR TITLE
Bet updates (#241, #332)

### DIFF
--- a/discordbot/modals/addoption.py
+++ b/discordbot/modals/addoption.py
@@ -80,6 +80,7 @@ class AddBetOption(discord.ui.Modal):
             _index = outcome_count + outcomes.index(outcome)
             _emoji = self.multiple_options_emojis[_index]
             self.bet["option_dict"][_emoji] = {"val": outcome}
+            self.bet["option_vals"].append(outcome)
 
         # extend bet's timeout
         created = self.bet["created"]
@@ -97,7 +98,8 @@ class AddBetOption(discord.ui.Modal):
                     "options": self.bet["options"],
                     "option_dict": self.bet["option_dict"],
                     "updated": now,
-                    "timeout": ending
+                    "timeout": ending,
+                    "option_vals": self.bet["option_vals"]
                 }
             }
         )

--- a/discordbot/modals/addoption.py
+++ b/discordbot/modals/addoption.py
@@ -1,0 +1,110 @@
+
+import datetime
+from logging import Logger
+
+import discord
+
+import discordbot.views.bet  # avoiding a circular import (:
+from discordbot.embedmanager import EmbedManager
+from discordbot.slashcommandeventclasses.close import CloseBet
+from discordbot.slashcommandeventclasses.place import PlaceBet
+from discordbot.utilities import PlaceHolderLogger
+from mongo.bsepoints.bets import UserBets
+from mongo.datatypes import Bet
+
+
+class AddBetOption(discord.ui.Modal):
+    def __init__(
+        self,
+        bet: Bet,
+        bseddies_place: PlaceBet,
+        bseddies_close: CloseBet,
+        logger: Logger = PlaceHolderLogger,
+        *args,
+        **kwargs
+    ) -> None:
+        super().__init__(*args, title="Add bet outcomes", **kwargs)
+
+        # option emojis
+        self.multiple_options_emojis = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "0️⃣"]
+
+        self.logger: Logger = logger
+        self.bet: Bet = bet
+        self.place: PlaceBet = bseddies_place
+        self.close: CloseBet = bseddies_close
+        self.embed_manager = EmbedManager()
+        self.user_bets = UserBets()
+
+        self.bet_options = discord.ui.InputText(
+            label="Enter the new outcome(s) on separate lines",
+            placeholder="New outcome 1...\nNew outcome 2...\nNew outcome 3...\netc, etc...",
+            style=discord.InputTextStyle.long
+        )
+
+        self.add_item(self.bet_options)
+
+    async def callback(self, interaction: discord.Interaction):
+        """
+
+        :param interaction:
+        :return:
+        """
+        await interaction.response.defer(ephemeral=True)
+
+        outcome = self.bet_options.value
+        outcomes = outcome.split("\n")
+
+        now = datetime.datetime.now()
+
+        if not outcomes:
+            await interaction.followup.send(
+                content="You need to provide at least one additional outcome",
+                ephemeral=True,
+                delete_after=10
+            )
+            return
+
+        outcome_count = len(self.bet["options"])
+
+        if len(outcomes) + outcome_count > 10:
+            await interaction.followup.send(
+                content="A bet cannot have more than ten outcomes",
+                ephemeral=True,
+                delete_after=10
+            )
+            return
+
+        self.bet["options"].extend(outcomes)
+
+        for outcome in outcomes:
+            _index = outcome_count + outcomes.index(outcome)
+            _emoji = self.multiple_options_emojis[_index]
+            self.bet["option_dict"][_emoji] = {"val": outcome}
+
+        # extend bet's timeout
+        created = self.bet["created"]
+        ending = self.bet["timeout"]
+
+        expired = now - created
+        ending += expired
+
+        self.bet["timeout"] = ending
+
+        self.user_bets.update(
+            {"_id": self.bet["_id"]},
+            {
+                "$set": {
+                    "options": self.bet["options"],
+                    "option_dict": self.bet["option_dict"],
+                    "updated": now,
+                    "timeout": ending
+                }
+            }
+        )
+
+        channel = await interaction.guild.fetch_channel(self.bet["channel_id"])
+        message = await channel.fetch_message(self.bet["message_id"])
+        embed = self.embed_manager.get_bet_embed(interaction.guild, self.bet["bet_id"], self.bet)
+        view = discordbot.views.bet.BetView(self.bet, self.place, self.close)
+        await message.edit(embed=embed, view=view)
+        await interaction.followup.send(content="Sorted.", ephemeral=True)

--- a/discordbot/tasks/guildchecker.py
+++ b/discordbot/tasks/guildchecker.py
@@ -227,6 +227,17 @@ class GuildChecker(BaseTask):
                 except discord.NotFound:
                     continue
 
+            # add our new fields for our new bets
+            self.logger.info("Updated bet fields")
+            all_bets = self.user_bets.query({"guild_id": guild.id, "type": {"$ne": "counter"}})
+            for bet in all_bets:
+                betters = bet.get("betters", {})
+                users = [int(user) for user in betters.keys()]
+                option_vals = [
+                    bet["option_dict"][o]["val"] for o in bet["option_dict"]
+                ]
+                self.user_bets.update({"_id": bet["_id"]}, {"$set": {"users": users, "option_vals": option_vals}})
+
             self.bot.add_view(LeaderBoardView(self.embed_manager))
 
             self.logger.info(f"Finishing checking {guild.name}")

--- a/discordbot/views/bet.py
+++ b/discordbot/views/bet.py
@@ -1,9 +1,12 @@
 
+import datetime
+
 import discord
 
 from discordbot.modals.addoption import AddBetOption
 from discordbot.slashcommandeventclasses.close import CloseBet
 from discordbot.slashcommandeventclasses.place import PlaceBet
+from discordbot.views.betchange import BetChange
 
 from mongo.bsepoints.bets import UserBets
 from mongo.datatypes import Bet
@@ -47,6 +50,33 @@ class BetView(discord.ui.View):
 
         option_modal = AddBetOption(_bet, self.place, self.close)
         await interaction.response.send_modal(option_modal)
+
+    @discord.ui.button(label="Change your bet", style=discord.ButtonStyle.gray)
+    async def change_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
+
+        _bet = self.user_bets.get_bet_from_id(self.bet["guild_id"], self.bet["bet_id"])
+
+        if str(interaction.user.id) not in _bet["betters"]:
+            message = "You can't change your bet for a bet you haven't bet on yet."
+            await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
+            return
+
+        _bet = self.user_bets.get_bet_from_id(self.bet["guild_id"], self.bet["bet_id"])
+
+        if not _bet["active"] or _bet.get("closed", False):
+            message = "Bet is closed - you can't change your bet."
+            await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
+            return
+
+        first_bet_time = _bet["betters"][str(interaction.user.id)]["first_bet"]
+        now = datetime.datetime.now()
+        if (now - first_bet_time).seconds > 600 and (now - _bet.get("updated", _bet["created"])).seconds > 600:
+            message = "It's been too long since your original bet - you can't change it now."
+            await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
+            return
+
+        _view = BetChange(_bet, self.place, self.close)
+        await interaction.response.send_message(content="Select another bet option.", view=_view, ephemeral=True)
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="✖️")
     async def cancel_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:

--- a/discordbot/views/bet.py
+++ b/discordbot/views/bet.py
@@ -1,21 +1,26 @@
 
 import discord
 
+from discordbot.modals.addoption import AddBetOption
 from discordbot.slashcommandeventclasses.close import CloseBet
 from discordbot.slashcommandeventclasses.place import PlaceBet
+
+from mongo.bsepoints.bets import UserBets
+from mongo.datatypes import Bet
 
 
 class BetView(discord.ui.View):
     def __init__(
         self,
-        bet: dict,
+        bet: Bet,
         bseddies_place: PlaceBet,
         bseddies_close: CloseBet
     ):
         super().__init__(timeout=None)
-        self.bet = bet
-        self.place = bseddies_place
-        self.close = bseddies_close
+        self.bet: Bet = bet
+        self.place: PlaceBet = bseddies_place
+        self.close: CloseBet = bseddies_close
+        self.user_bets = UserBets()
 
     @discord.ui.button(label="Place a bet", style=discord.ButtonStyle.blurple, emoji="💰")
     async def place_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
@@ -24,6 +29,24 @@ class BetView(discord.ui.View):
     @discord.ui.button(label="Close this bet", style=discord.ButtonStyle.gray)
     async def close_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
         await self.close.create_bet_view(interaction, [self.bet, ])
+
+    @discord.ui.button(label="Add option", style=discord.ButtonStyle.gray)
+    async def add_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
+
+        if interaction.user.id != self.bet["user"]:
+            message = "You weren't the bet creator - you can't do this."
+            await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
+            return
+
+        _bet = self.user_bets.get_bet_from_id(self.bet["guild_id"], self.bet["bet_id"])
+
+        if not _bet["active"] or _bet.get("closed", False):
+            message = "Bet isn't available to add more options."
+            await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
+            return
+
+        option_modal = AddBetOption(_bet, self.place, self.close)
+        await interaction.response.send_modal(option_modal)
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, emoji="✖️")
     async def cancel_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:

--- a/discordbot/views/bet.py
+++ b/discordbot/views/bet.py
@@ -56,7 +56,7 @@ class BetView(discord.ui.View):
 
         _bet = self.user_bets.get_bet_from_id(self.bet["guild_id"], self.bet["bet_id"])
 
-        if str(interaction.user.id) not in _bet["betters"]:
+        if interaction.user.id not in _bet["users"]:
             message = "You can't change your bet for a bet you haven't bet on yet."
             await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
             return
@@ -70,7 +70,7 @@ class BetView(discord.ui.View):
 
         first_bet_time = _bet["betters"][str(interaction.user.id)]["first_bet"]
         now = datetime.datetime.now()
-        if (now - first_bet_time).seconds > 600 and (now - _bet.get("updated", _bet["created"])).seconds > 600:
+        if (now - first_bet_time).seconds > 300 and (now - _bet.get("updated", _bet["created"])).seconds > 300:
             message = "It's been too long since your original bet - you can't change it now."
             await interaction.response.send_message(content=message, ephemeral=True, delete_after=10)
             return

--- a/discordbot/views/betchange.py
+++ b/discordbot/views/betchange.py
@@ -1,0 +1,70 @@
+
+import discord
+
+import discordbot.views.bet
+from discordbot.embedmanager import EmbedManager
+from discordbot.selects.betoutcomes import BetOutcomesSelect
+from discordbot.slashcommandeventclasses.close import CloseBet
+from discordbot.slashcommandeventclasses.place import PlaceBet
+
+from mongo.bsepoints.bets import UserBets
+from mongo.datatypes import Bet
+
+
+class BetChange(discord.ui.View):
+    def __init__(
+        self,
+        bet: Bet,
+        place: PlaceBet,
+        close: CloseBet
+    ):
+        super().__init__(timeout=None)
+        self.bet: Bet = bet
+        self.user_bets = UserBets()
+        self.embed_manager = EmbedManager()
+
+        self.place = place
+        self.close = close
+
+        outcomes = bet["option_dict"]
+        options = [
+            discord.SelectOption(
+                label=outcomes[key]["val"],
+                value=key,
+                emoji=key
+            ) for key in outcomes
+        ]
+
+        self.outcome_select = BetOutcomesSelect(options, discord.ui.Button)
+        self.add_item(self.outcome_select)
+
+    @discord.ui.button(label="Submit", style=discord.ButtonStyle.green, row=2)
+    async def place_callback(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
+
+        await interaction.response.defer(ephemeral=True)
+
+        value = self.outcome_select.values[0]
+
+        self.bet["betters"][str(interaction.user.id)]["emoji"] = value
+
+        self.user_bets.update(
+            {"_id": self.bet["_id"]},
+            {"$set": {f"betters.{interaction.user.id}.emoji": value}}
+        )
+
+        # refresh view for users
+        bet = self.user_bets.get_bet_from_id(interaction.guild_id, self.bet["bet_id"])
+        channel = await interaction.guild.fetch_channel(bet["channel_id"])
+        message = await channel.fetch_message(bet["message_id"])
+        embed = self.embed_manager.get_bet_embed(interaction.guild, bet["bet_id"], bet)
+        view = discordbot.views.bet.BetView(bet, self.place, self.close)
+        await message.edit(embed=embed, view=view)
+        await interaction.followup.edit_message(
+            message_id=interaction.message.id,
+            content="Updated your bet for you.",
+            view=None
+        )
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red, row=2, disabled=False, emoji="✖️")
+    async def cancel_callback(self, button: discord.ui.Button, interaction: discord.Interaction):
+        await interaction.response.edit_message(content="Cancelled", view=None, ephemeral=True)

--- a/discordbot/views/taxrate.py
+++ b/discordbot/views/taxrate.py
@@ -56,7 +56,7 @@ class TaxRateView(discord.ui.View):
             channel = interaction.guild.get_channel(channel_id)
             msg = (
                 f"{interaction.user.mention} has changed the tax rate to `{value}` "
-                "and the supporter tax rate to `{supporter_value}`! 📈"
+                f"and the supporter tax rate to `{supporter_value}`! 📈"
             )
             await channel.send(content=msg)
 

--- a/mongo/datatypes.py
+++ b/mongo/datatypes.py
@@ -104,6 +104,10 @@ class Bet(TypedDict):
     """Title of the bet"""
     options: list[str]
     """List of option emojis"""
+    option_vals: list[str]
+    """List of option values"""
+    users: list[int]
+    """List of user IDs"""
     created: datetime.datetime
     """The time the bet was created"""
     timeout: datetime.datetime

--- a/mongo/datatypes.py
+++ b/mongo/datatypes.py
@@ -1,6 +1,7 @@
 
 import datetime
 from typing import TypedDict, Union
+
 try:
     from typing import NotRequired
 except ImportError:


### PR DESCRIPTION
This update is threefold:
- Allow the creator of the bet to add another option post-creation
- Allow users to change their bets to some extent
- Add some extra top-level fields for bets that will make future easier (#403)

Users will only be able to change their bets 5 minutes after they placed theirs, or five minutes after a new option was added. This is mainly targeting the use case where people place on one outcome accidentally or wish to change it after placing it too quickly without thinking. Adding a new bet option allows users to change their existing bets if they want to change it to the new one. Made it five minutes to prevent users changing a bet after the real outcome becomes clear; though this might be changed in the future to be a certain fraction of the total bet time (longer bets should have more leeway for changing their mind).