### PR TITLE
#404 - Additional message actions

### DIFF
--- a/discordbot/clienteventclasses/onmessage.py
+++ b/discordbot/clienteventclasses/onmessage.py
@@ -10,7 +10,9 @@ from discordbot.message_actions.base import BaseMessageAction  # noqa
 
 # message actions
 from discordbot.message_actions.birthday_replies import BirthdayReplies
+from discordbot.message_actions.duplicate_links import DuplicateLinkAction
 from discordbot.message_actions.marvel_ad import MarvelComicsAdAction
+from discordbot.message_actions.remind_me import RemindMeAction
 from discordbot.message_actions.thank_you_replies import ThankYouReplies
 from discordbot.message_actions.wordle_reactions import WordleMessageAction
 
@@ -24,9 +26,11 @@ class OnMessage(BaseEvent):
         super().__init__(client, guild_ids, logger)
         self._post_message_action_classes = [
             BirthdayReplies(client),
+            DuplicateLinkAction(client),
             MarvelComicsAdAction(client),
+            RemindMeAction(client),
             ThankYouReplies(client),
-            WordleMessageAction(client)
+            WordleMessageAction(client),
         ]  # type: list[BaseMessageAction]
 
     async def message_received(

--- a/discordbot/constants.py
+++ b/discordbot/constants.py
@@ -140,3 +140,5 @@ WORDLE_SCORE_REGEX = r"[\dX]/\d"
 
 # cool down in seconds for marvel ad messages
 MARVEL_AD_COOLDOWN = 3600
+# cool down in seconds for remind me reminders
+REMIND_ME_COOLDOWN = 3600

--- a/discordbot/message_actions/base.py
+++ b/discordbot/message_actions/base.py
@@ -2,6 +2,8 @@
 import discord
 
 from discordbot.bsebot import BSEBot
+from mongo.bsepoints.guilds import Guilds
+from mongo.bsepoints.interactions import UserInteractions
 
 
 class BaseMessageAction():
@@ -10,6 +12,8 @@ class BaseMessageAction():
     """
     def __init__(self, client: BSEBot) -> None:
         self.client = client
+        self.user_interactions = UserInteractions()
+        self.guilds = Guilds()
 
     async def pre_condition(self, message: discord.Message, message_type: list) -> bool:
         """

--- a/discordbot/message_actions/duplicate_links.py
+++ b/discordbot/message_actions/duplicate_links.py
@@ -1,0 +1,99 @@
+
+import datetime
+import random
+import re
+
+import discord
+from pymongo.errors import OperationFailure
+
+from discordbot.bsebot import BSEBot
+from discordbot.message_actions.base import BaseMessageAction
+from discordbot.message_strings.duplicate_links import MESSAGES
+
+
+class DuplicateLinkAction(BaseMessageAction):
+    """
+    Duplicated Link action
+    """
+    def __init__(self, client: BSEBot) -> None:
+        super().__init__(client)
+        # allow the precondition to store results for the run to use
+        self._results_map = {
+
+        }
+
+    async def pre_condition(self, message: discord.Message, message_type: list) -> bool:
+        """
+        Duplicated links precondition
+
+        Args:
+            message (discord.Message): message to check
+            message_type (list): the precalculated message_type of the message
+
+        Returns:
+            bool: true or false
+        """
+
+        if "link" not in message_type or message.author.bot:
+            return False
+
+        # extract link from content
+        link = [_link for _link in re.split(" \n", message.content) if "https" in _link][0]
+        link = link.split("?")[0]
+
+        if "guessthe.game" in link:
+            return False
+
+        # only care about dupes if the original was posted within a couple of days
+        threshold = datetime.datetime.now() - datetime.timedelta(days=2)
+        try:
+            results = self.user_interactions.query(
+                {
+                    "guild_id": message.guild.id,
+                    "is_bot": False,  # don't care if the original poster was a bot
+                    "message_id": {"$ne": message.id},  # don't trigger off of original message
+                    "$text": {"$search": link},
+                    "timestamp": {"$gte": threshold}
+                }
+            )
+        except OperationFailure:
+            # index not set correctly
+            # could be local dev env
+            return False
+
+        if not results:
+            return False
+
+        results = [
+            result for result in results if link in result["content"]
+        ]
+
+        if not results:
+            return False
+
+        results = sorted(results, key=lambda x: x["timestamp"], reverse=False)
+        self._results_map[message.id] = results
+        return True
+
+    async def run(self, message: discord.Message) -> None:
+        """Duplicate link action
+
+        Args:
+            message (discord.Message): the message to action
+        """
+
+        original = self._results_map[message.id][0]
+
+        # link to the original message
+        original_message_link = (
+            f"https://discord.com/channels/{message.guild.id}/{original['channel_id']}/{original['message_id']}"
+        )
+
+        msg = random.choice(MESSAGES)
+        msg = msg.format(mention=f"<@{original['user_id']}>")
+        msg += f"\n\n{original_message_link}"
+
+        await message.reply(content=msg, suppress=True)
+
+        # remove results
+        self._results_map.pop(message.id)

--- a/discordbot/message_actions/remind_me.py
+++ b/discordbot/message_actions/remind_me.py
@@ -5,28 +5,29 @@ import re
 import discord
 
 from discordbot.bsebot import BSEBot
-from discordbot.constants import MARVEL_AD_COOLDOWN
+from discordbot.constants import REMIND_ME_COOLDOWN
 from discordbot.message_actions.base import BaseMessageAction
 
 
-class MarvelComicsAdAction(BaseMessageAction):
+class RemindMeAction(BaseMessageAction):
     """
-    Marvel comic add message action
+    Remind Me message action
+    Suggests to users to use the bot's remind me functionality
     """
     def __init__(self, client: BSEBot) -> None:
         super().__init__(client)
 
-        self._comic_terms = [
-            "comic",
-            "comics",
-            "marvel",
+        self._reminder_terms = [
+            "remind me",
+            "remindme",
+            "need a reminder",
         ]
 
     async def pre_condition(self, message: discord.Message, message_type: list) -> bool:
         """
-        Marvel comics ad precondition
+        Remind me precondition
         Checks that the message contains our triggers and that it's mean more than the cooldown since the
-        last time we sent an ad
+        last time we sent a reminder
 
         Args:
             message (discord.Message): message to check
@@ -35,31 +36,33 @@ class MarvelComicsAdAction(BaseMessageAction):
         Returns:
             bool: true or false
         """
-        if any([re.match(rf"\b{a}\b", message.content.lower()) for a in self._comic_terms]):
+        if any([re.match(rf"\b{a}\b", message.content.lower()) for a in self._reminder_terms]):
             # check last time that we sent a marvel comic ad
             now = datetime.datetime.now()
-            _last_time = self.guilds.get_last_ad_time(message.guild.id)
+            _last_time = self.guilds.get_last_remind_me_time(message.guild.id)
             if _last_time:
-                if (now - _last_time).total_seconds() < MARVEL_AD_COOLDOWN:
+                if (now - _last_time).total_seconds() < REMIND_ME_COOLDOWN:
                     return False
-            self.guilds.set_last_ad_time(message.guild.id, now)
+            self.guilds.set_last_remind_me_time(message.guild.id, now)
             return True
         return False
 
     async def run(self, message: discord.Message) -> None:
-        """Marvel ad action
+        """Remind me action
 
         Args:
             message (discord.Message): the message to action
         """
 
         msg = (
-            "**A World of Comics Awaits.\n\n**"
-            "Get access to tens of thousands of Marvel comics for under a tenner a month!\n"
-            "Try for _free_ for _7_ days and then "
-            "get _50%_ off your first two months with code **BSEBOT**.\n\n"
-            "https://www.marvel.com/unlimited\n\n"
-            "**#AD**"
+            "# Looking for a reminder?\n"
+            "Use `/remindme` to set a new reminder in Discord.\n"
+            "_Or_, to be reminded about an existing message:"
+            "\n- right-click the message"
+            "\n- press *Apps*"
+            "\n- press *Remind me*"
+            "\n\n"
+            "To see other commands, use `/help`."
         )
 
         await message.reply(content=msg, suppress=True)

--- a/discordbot/message_strings/duplicate_links.py
+++ b/discordbot/message_strings/duplicate_links.py
@@ -1,0 +1,9 @@
+# file for duplicate link callouts
+# will be sent when someone posts a link that someone has already posted
+# {mention} is where the ORIGINAL author will be tagged
+# one of these will be picked at random
+# to add a new one, simply add a new line
+
+MESSAGES = [
+    "{mention} check out the disrepect on this guy",
+]

--- a/mongo/bsepoints/guilds.py
+++ b/mongo/bsepoints/guilds.py
@@ -421,6 +421,40 @@ class Guilds(BestSummerEverPointsDB):
         return ret
 
     #
+    # Remind me reminder stuff
+    #
+
+    def get_last_remind_me_time(self, guild_id: int) -> datetime.datetime:
+        """
+        Gets the last remind me suggestion time
+
+        Args:
+            guild_id (int): the guild ID to do this for
+
+        Returns:
+            dateteime: the time this guild last had a marvel comics ad
+        """
+        ret = self.query({"guild_id": guild_id}, projection={"last_remind_me_suggest_time": True})
+        if not ret or "last_remind_me_suggest_time" not in ret[0]:
+            return None
+        ret = ret[0]
+        return ret["last_remind_me_suggest_time"]
+
+    def set_last_remind_me_time(self, guild_id: int, timestamp: datetime.datetime) -> UpdateResult:
+        """
+        Sets the last remind me suggested time
+
+        Args:
+            guild_id (int): the guild ID to do this for
+            timestamp (datetime): the timestamp to set
+
+        Returns:
+            UpdateResult: update result
+        """
+        ret = self.update({"guild_id": guild_id}, {"$set": {"last_remind_me_suggest_time": timestamp}})
+        return ret
+
+    #
     # Valorant stuff
     #
 


### PR DESCRIPTION
Added two new message actions:
- a `remind me` message action, triggering if it seems the user wants to set a reminder. This informs the user about the possibility of using the bot to set a reminder. This is on a cooldown
- a `duplicated link` message action. This triggers if the same link was posted in the same server within the last couple of days.