### PR TITLE
#408, #102 - Dynamic random message odds

### DIFF
--- a/discordbot/tasks/dailyvallytask.py
+++ b/discordbot/tasks/dailyvallytask.py
@@ -5,6 +5,7 @@ import random
 from logging import Logger
 
 from discord.ext import tasks
+from pymongo.errors import OperationFailure
 
 from discordbot.bsebot import BSEBot
 from discordbot.constants import BSE_SERVER_ID
@@ -96,7 +97,46 @@ class AfterWorkVally(BaseTask):
             else:
                 _mention = "`Valorant`"
 
-            message = random.choice(MESSAGES)
+            # work out message odds
+            odds = []
+            totals = {}
+            # get the number of times each rollcall message has been used
+            for message in MESSAGES:
+                parts = message.split("{role}")
+                main_bit = sorted(parts, key=lambda x: len(x), reverse=True)[0]
+
+                try:
+                    results = self.interactions.query(
+                        {
+                            "guild_id": guild.id,
+                            "is_bot": True,
+                            "$text": {"$search": message}
+                        }
+                    )
+                    results = [result for result in results if main_bit in result["content"]]
+                except OperationFailure:
+                    totals[message] = 0
+                    continue
+
+                totals[message] = len(results)
+
+            # work out the weight that a given message should be picked
+            total_rollcalls = sum(totals.values())
+            for message in MESSAGES:
+                _times = totals[message]
+                _chance = (1 - (_times / total_rollcalls)) * 100
+
+                # give greater weighting to standard messages
+                if MESSAGES.index(message) in [0, 1]:
+                    _chance += 25
+
+                # give greater weighting to those with 0 uses so far
+                if _times == 0:
+                    _chance += 25
+
+                odds.append((message, _chance))
+
+            message = random.choices([message[0] for message in totals], [message[1] for message in totals])
             message = message.format(role=_mention)
 
             self.logger.info(f"Sending daily vally message: {message}")

--- a/discordbot/tasks/wordlereminder.py
+++ b/discordbot/tasks/wordlereminder.py
@@ -2,11 +2,10 @@
 import asyncio
 import datetime
 import random
-
 from logging import Logger
 
-
 from discord.ext import tasks
+from pymongo.errors import OperationFailure
 
 from discordbot import utilities
 from discordbot.bsebot import BSEBot
@@ -91,6 +90,45 @@ class WordleReminder(BaseTask):
                 self.logger.info("Everyone has done their wordle today!")
                 continue
 
+            # work out message odds
+            odds = []
+            totals = {}
+            # get the number of times each reminder message has been used
+            for message in MESSAGES:
+                parts = message.split("{mention}")
+                main_bit = sorted(parts, key=lambda x: len(x), reverse=True)[0]
+
+                try:
+                    results = self.interactions.query(
+                        {
+                            "guild_id": guild.id,
+                            "is_bot": True,
+                            "$text": {"$search": message}
+                        }
+                    )
+                    results = [result for result in results if main_bit in result["content"]]
+                except OperationFailure:
+                    totals[message] = 0
+                    continue
+
+                totals[message] = len(results)
+
+            # work out the weight that a given message should be picked
+            total_reminder_messages = sum(totals.values())
+            for message in MESSAGES:
+                _times = totals[message]
+                _chance = (1 - (_times / total_reminder_messages)) * 100
+
+                # give greater weighting to standard messages
+                if MESSAGES.index(message) in [0, 1]:
+                    _chance += 25
+
+                # give greater weighting to those with 0 uses so far
+                if _times == 0:
+                    _chance += 25
+
+                odds.append((message, _chance))
+
             for reminder in reminders_needed:
                 if reminder["user_id"] == BSE_BOT_ID:
                     # skip bot reminder
@@ -107,7 +145,7 @@ class WordleReminder(BaseTask):
 
                 y_message = await channel.fetch_message(reminder["message_id"])
 
-                message = random.choice(MESSAGES)
+                message = random.choices([message[0] for message in totals], [message[1] for message in totals])
                 message = message.format(mention=y_message.author.mention)
 
                 self.logger.info(message)

--- a/discordbot/tasks/wordlereminder.py
+++ b/discordbot/tasks/wordlereminder.py
@@ -97,6 +97,7 @@ class WordleReminder(BaseTask):
                 [0, 1],
             )
 
+            _messages_sent = ["", ]
             for reminder in reminders_needed:
                 if reminder["user_id"] == BSE_BOT_ID:
                     # skip bot reminder
@@ -113,7 +114,12 @@ class WordleReminder(BaseTask):
 
                 y_message = await channel.fetch_message(reminder["message_id"])
 
-                message = random.choices([message[0] for message in odds], [message[1] for message in odds])
+                # make sure that we send different messages for each needed reminder
+                message = ""
+                while message in _messages_sent:
+                    message = random.choices([message[0] for message in odds], [message[1] for message in odds])
+
+                _messages_sent.append(message)
                 message = message.format(mention=y_message.author.mention)
 
                 self.logger.info(message)

--- a/discordbot/utilities.py
+++ b/discordbot/utilities.py
@@ -10,6 +10,10 @@ import re
 import sys
 from logging.handlers import RotatingFileHandler
 
+from pymongo.errors import OperationFailure
+
+from mongo.bsepoints.interactions import UserInteractions
+
 
 class PlaceHolderLogger():
     """
@@ -153,3 +157,68 @@ def add_utc_offset(date: datetime.datetime) -> datetime.datetime:
 def is_utc(date: datetime.datetime) -> bool:
     now_utc = datetime.datetime.now(tz=datetime.timezone.utc)
     return now_utc.hour == date.hour
+
+
+def calculate_message_odds(
+    interactions: UserInteractions,
+    guild_id: int,
+    message_list: list[str],
+    split: str,
+    main_indexes: list[int],
+) -> list[tuple[str, float]]:
+    """
+    Given a list of messages, calculates what the odds should be of each one getting picked.
+    This searches for previously used instances of those messages and then works out which ones should have
+    higher/lower odds.
+
+    Args:
+        interactions (UserInteractions): UserInteractions class for queries
+        guild_id (int): the guild ID
+        message_list (list[str]): the list of messages to get odds for
+        split (str): the marker to split the list of messages on to validate text search results
+        main_indexes (list[int]): the indexes of the messages that get extra odds
+
+    Returns:
+        list[tuple[str, float]]: list of messages tuples with the original string and the float percentage chance
+    """
+
+    # work out message odds
+    odds = []
+    totals = {}
+    # get the number of times each rollcall message has been used
+    for message in message_list:
+        parts = message.split(split)
+        main_bit = sorted(parts, key=lambda x: len(x), reverse=True)[0]
+
+        try:
+            results = interactions.query(
+                {
+                    "guild_id": guild_id,
+                    "is_bot": True,
+                    "$text": {"$search": message}
+                }
+            )
+            results = [result for result in results if main_bit in result["content"]]
+        except OperationFailure:
+            totals[message] = 0
+            continue
+
+        totals[message] = len(results)
+
+    # work out the weight that a given message should be picked
+    total_rollcalls = sum(totals.values())
+    for message in message_list:
+        _times = totals[message]
+        _chance = (1 - (_times / total_rollcalls)) * 100
+
+        # give greater weighting to standard messages
+        if message_list.index(message) in main_indexes:
+            _chance += 25
+
+        # give greater weighting to those with 0 uses so far
+        if _times == 0:
+            _chance += 25
+
+        odds.append((message, _chance))
+
+    return odds

--- a/discordbot/utilities.py
+++ b/discordbot/utilities.py
@@ -206,10 +206,10 @@ def calculate_message_odds(
         totals[message] = len(results)
 
     # work out the weight that a given message should be picked
-    total_rollcalls = sum(totals.values())
+    total_values = sum(totals.values())
     for message in message_list:
         _times = totals[message]
-        _chance = (1 - (_times / total_rollcalls)) * 100
+        _chance = (1 - (_times / total_values)) * 100
 
         # give greater weighting to standard messages
         if message_list.index(message) in main_indexes:


### PR DESCRIPTION
Add functionality that allows us the odds of random messages to be a bit more dynamic. Rather than each message having equal chance, give those messages that have been used less a bit more chance to be picked. Hopefully increasing the diversity of the messages chosen. Functionality added for Valorant daily rollcalls and Wordle reminder messages. Added into a function in `utilities.py` so that it can be reused in other places that will use it.

