### PR TITLE
#410 - Allow some hardcoded odds

### DIFF
--- a/discordbot/message_strings/valorant_rollcalls.py
+++ b/discordbot/message_strings/valorant_rollcalls.py
@@ -1,5 +1,7 @@
 # file for daily valorant message rollcalls
-# when sending a valorant rollcall message, it will pick one of these at random
+# when sending a valorant rollcall message
+# message will be chosen randomly, but based on some dynamically created odds
+# use a tuple to hardcode some odds
 # the '{role}' bit is where the valorant role mention will be inserted
 # to add a new one, simply add a new line
 
@@ -16,4 +18,8 @@ MESSAGES = [
     "Valorant? Valorant? VALORANT? VALROARANT? RAVALROANT? {role}",
     "I'm a little bot, it's time to get mad and play {role}?",
     "# Balls. {role}",
+
+    # HARD-CODED ODDS EXAMPLE
+    # tuple with message string as first item, chance (roughly out of 100) as a float
+    # ("This is a super rare message {role}", 1.0)
 ]

--- a/discordbot/message_strings/wordle_reminders.py
+++ b/discordbot/message_strings/wordle_reminders.py
@@ -1,5 +1,7 @@
 # file for daily vwordle reminders
 # when sending a wordle reminder message, it will pick one of these at random
+# message will be chosen randomly, but based on some dynamically created odds
+# use a tuple to hardcode some odds
 # the '{mention}' bit is where the user mention will be inserted
 # to add a new one, simply add a new line
 
@@ -12,4 +14,8 @@ MESSAGES = [
     "{mention} hasn't done their Wordle today. Are they stupid?",
     "Daddy wants you to complete your Wordle today {mention}",
     "{mention}\nRoses are red\nViolets are blue\nI've done my Wordle\nDon't forget to do yours too!",
+
+    # HARD-CODED ODDS EXAMPLE
+    # tuple with message string as first item, chance (roughly out of 100) as a float
+    # ("This is a super rare message {mention}", 1.0)
 ]

--- a/discordbot/tasks/dailyvallytask.py
+++ b/discordbot/tasks/dailyvallytask.py
@@ -105,7 +105,7 @@ class AfterWorkVally(BaseTask):
                 [0, 1],
             )
 
-            message = random.choices([message[0] for message in odds], [message[1] for message in odds])
+            message = random.choices([message[0] for message in odds], [message[1] for message in odds])[0]
             message = message.format(role=_mention)
 
             self.logger.info(f"Sending daily vally message: {message}")

--- a/discordbot/tasks/wordlereminder.py
+++ b/discordbot/tasks/wordlereminder.py
@@ -117,7 +117,7 @@ class WordleReminder(BaseTask):
                 # make sure that we send different messages for each needed reminder
                 message = ""
                 while message in _messages_sent:
-                    message = random.choices([message[0] for message in odds], [message[1] for message in odds])
+                    message = random.choices([message[0] for message in odds], [message[1] for message in odds])[0]
 
                 _messages_sent.append(message)
                 message = message.format(mention=y_message.author.mention)

--- a/discordbot/utilities.py
+++ b/discordbot/utilities.py
@@ -187,6 +187,18 @@ def calculate_message_odds(
     totals = {}
     # get the number of times each rollcall message has been used
     for message in message_list:
+
+        if type(message) == tuple:
+            # if message type is tuple
+            # assume odds are already set for it
+
+            if len(message) != 2 or type(message[0]) != str or type(message[1]) not in [int, float]:
+                # tuple isn't correctly formatted - skip this one
+                continue
+
+            odds.append(message)
+            continue
+
         parts = message.split(split)
         main_bit = sorted(parts, key=lambda x: len(x), reverse=True)[0]
 


### PR DESCRIPTION
Allows some hardcoded message odds. This works by adding a tuple to the list of message strings and defining the message string and the odds (roughly out of 100) as a float.

Updated message string docs and add an example.