### PR TITLE
Fix the salary error

### DIFF
--- a/discordbot/tasks/eddiegains.py
+++ b/discordbot/tasks/eddiegains.py
@@ -418,7 +418,7 @@ class BSEddiesManager(BaseTask):
                 if guesses != "X":
                     wordle_messages.append((user, guesses))
 
-            except IndexError:
+            except (IndexError, StopIteration):
                 # just means we had an error with this
                 pass
 


### PR DESCRIPTION
The recent linting update caused an error with the daily salary. A different error is thrown if we call `next` on a generator that has no items in.