### PR TITLE
fix: resolve issue with awards/stats 

### DIFF
--- a/discordbot/stats/statsdatacache.py
+++ b/discordbot/stats/statsdatacache.py
@@ -101,7 +101,7 @@ class StatsDataCache:
             {
                 "guild_id": guild_id,
                 "timestamp": {"$gt": start, "$lt": end},
-                "message_type": {"$nin": ["emoji_used", "vc_joined", "vc_streaming"]},
+                "message_type": "message",
                 "is_bot": {"$ne": True},
             },
         )
@@ -140,7 +140,7 @@ class StatsDataCache:
                 "guild_id": guild_id,
                 "edited": {"$gt": start, "$lt": end},
                 "edit_count": {"$gte": 1},
-                "message_type": {"$nin": ["emoji_used", "vc_joined", "vc_streaming"]},
+                "message_type": "message",
                 "is_bot": {"$ne": True},
             },
         )


### PR DESCRIPTION
Changing the message means that we actually return what we want. MongoDB behaviours weirdly when it's the other way around.